### PR TITLE
Add env variables for num_zones and num_pods

### DIFF
--- a/Ansible/group_vars/all.sample
+++ b/Ansible/group_vars/all.sample
@@ -88,6 +88,8 @@ def_env_uuid: "unknown"
 # Environment database settings
 def_env_db_name: "trillian_envs"
 def_env_db_ip: "<IP_ADDRESS_HERE>"
+def_env_num_pods: 1
+def_env_num_zones: 1
 
 
 # Environment summary


### PR DESCRIPTION
It looks like the all.sample file is missing two variables which make the generate-config fail. @PaulAngus 