### PR TITLE
Check for authorized_keys file before modifying it

### DIFF
--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -131,8 +131,14 @@
     - kvm
     - kvm-agent
 
+- name: Check if authorized_keys exists
+  stat:
+    path: /etc/file.txt
+    register: auth_keys_stat
+
 - name: Enable the root user because Cloudstack uses root account to add host
   shell: "sed -i 's/^.*\\(ssh-rsa .*$\\)/\\1/' /root/.ssh/authorized_keys"
+  when: auth_keys_stat.stat.exists == True
 
 - name: Change password for KVM host (usually root password)
   shell: "echo {{ kvm_password }} | passwd {{ kvm_username }} --stdin"


### PR DESCRIPTION
This fixes a case where we don't modify the `authorized_keys` if it doesn't exist