### PR TITLE
Fixing a bug in the runtests script, which was deleting all test_name…

### DIFF
--- a/Ansible/roles/marvin/templates/additionaltests.sh.j2
+++ b/Ansible/roles/marvin/templates/additionaltests.sh.j2
@@ -54,7 +54,10 @@ cleanup() {
 
 runtest() {
     file=$1
-    rm -fr $LOGDIR/$(basename $file).xml $LOGDIR/$(basename $file | sed 's/.py$//g')_*
+    rm -fr $LOGDIR/$(basename $file).xml
+    TRIMFILE=$file | sed 's/.py$//g'
+    OLDRESULT= ll $LOGDIR | grep -Ew '\<$TRIMFILE_[a-zA-Z0-9]{6}\>'
+    rm -fr $OLDRESULT    
     nosetests --with-xunit --xunit-file=$LOGDIR/$(basename $file).xml --with-marvin --marvin-config=/marvin/{{ env_name_clean }}-advanced-cfg --hypervisor={{ env_hv }} -a tags=advanced $file
     cleanup || true
 }
@@ -91,11 +94,12 @@ done
 
 GOOD=0
 BAD=0
-for dir in $LOGDIR/*/; do
-  if [[ -s ${dir}failed_plus_exceptions.txt ]]; then
-    BAD=$((BAD+1))
-  else
-    GOOD=$((GOOD+1))
+for file in $LOGDIR/*.xml; do
+  if grep --q 'errors="0" failures="0"' ${file}
+    then
+      GOOD=$((GOOD+1))
+    else
+      BAD=$((BAD+1))
   fi
 done
 echo "Test completed. $GOOD look ok, $BAD have errors"

--- a/Ansible/roles/marvin/templates/componenttests.sh.j2
+++ b/Ansible/roles/marvin/templates/componenttests.sh.j2
@@ -50,7 +50,10 @@ cleanup() {
 
 runtest() {
     file=$1
-    rm -fr $LOGDIR/$(basename $file).xml $LOGDIR/$(basename $file | sed 's/.py$//g')_*
+    rm -fr $LOGDIR/$(basename $file).xml
+    TRIMFILE=$file | sed 's/.py$//g'
+    OLDRESULT= ll $LOGDIR | grep -Ew '\<$TRIMFILE_[a-zA-Z0-9]{6}\>'
+    rm -fr $OLDRESULT    
     nosetests --with-xunit --xunit-file=$LOGDIR/$(basename $file).xml --with-marvin --marvin-config=/marvin/{{ env_name_clean }}-advanced-cfg --hypervisor={{ env_hv }} -a tags=advanced $file
     cleanup || true
 }
@@ -114,14 +117,14 @@ done
 
 GOOD=0
 BAD=0
-for dir in $LOGDIR/*/; do
-  if [[ -s ${dir}failed_plus_exceptions.txt ]]; then
-    BAD=$((BAD+1))
-  else
-    GOOD=$((GOOD+1))
-  fi
+for file in $LOGDIR/*.xml; do
+  if grep --q 'errors="0" failures="0"' ${file}
+    then
+      GOOD=$((GOOD+1))
+    else
+      BAD=$((BAD+1))
+  if
 done
-
 echo "Test completed. $GOOD look ok, $BAD have errors"
 {% if use_hipchat %}hipchat --action sendNotification --room "Marvin Notifications" --messageFormat "html" --message "Component tests for <b>{{ env_name_clean }}</b> completed. <br><b>$GOOD</b> look ok, <b>$BAD</b> have errors" --colour "green" --notify{% endif %}
 

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -52,7 +52,10 @@ cleanup() {
 
 runtest() {
     file=$1
-    rm -fr $LOGDIR/$(basename $file).xml $LOGDIR/$(basename $file | sed 's/.py$//g')*
+    rm -fr $LOGDIR/$(basename $file).xml
+    TRIMFILE=$file | sed 's/.py$//g'
+    OLDRESULT= ll $LOGDIR | grep -Ew '\<$TRIMFILE_[a-zA-Z0-9]{6}\>'
+    rm -fr $OLDRESULT    
     nosetests --with-xunit --xunit-file=$LOGDIR/$(basename $file).xml --with-marvin --marvin-config=/marvin/{{ env_name_clean }}-advanced-cfg --hypervisor={{ env_hv }} -a tags=advanced $file
     cleanup || true
 }
@@ -90,11 +93,12 @@ done
 
 GOOD=0
 BAD=0
-for dir in $LOGDIR/*/; do
-  if [[ -s ${dir}failed_plus_exceptions.txt ]]; then
-    BAD=$((BAD+1))
-  else
-    GOOD=$((GOOD+1))
+for file in $LOGDIR/*.xml; do
+  if grep --q 'errors="0" failures="0"' ${file}
+    then
+      GOOD=$((GOOD+1))
+    else
+      BAD=$((BAD+1))
   fi
 done
 echo "Test completed. $GOOD look ok, $BAD have errors"


### PR DESCRIPTION
…_* files and dirs, which caused deleting logs of lookalike tests. For example test_affinity_groups was deleting previously executed test_affinity_groups_projects because of the asterisk (*). The other fix was the way we determine if tests are good or bad, switched it to look for the result xml instead of failed_plus_exceptions file since the that is the actual source of test result, other txt files are parsed and could be corrupt.