### PR TITLE
Elrepokernel

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/setupdb.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/setupdb.yml
@@ -86,7 +86,7 @@
   shell: "curl http://127.0.0.1:8080/client/api --connect-timeout 5"
   register: result
   until: result.stdout.find("unable to verify user") != -1
-  retries: 50
+  retries: 100
   run_once: true
 
 - name: Setup management on additional cloudstack management servers

--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -198,16 +198,7 @@
 - name: Change password for KVM host (usually root password)
   shell: "echo {{ kvm_password }} | passwd {{ kvm_username }} --stdin"
 
-- name: Setup ELrepo-kernel yum repository
-  template: src="{{ inventory_dir }}/templates/{{ item }}.j2" dest="/etc/yum.repos.d/{{item}}"
-  with_items:
-    - "elrepo.repo"
-  when: kvm_install_elrepo_kernel
-  tags:
-    - kvm
-
-- name: Install ELrepo kernel
-  shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }}"
-  when: kvm_install_elrepo_kernel
+- include: ./centos_elrepokernel.yml
+  when: kvm_install_elrepo_kernel 
   tags:
     - kvm

--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -197,3 +197,17 @@
 
 - name: Change password for KVM host (usually root password)
   shell: "echo {{ kvm_password }} | passwd {{ kvm_username }} --stdin"
+
+- name: Setup ELrepo-kernel yum repository
+  template: src="{{ inventory_dir }}/templates/{{ item }}.j2" dest="/etc/yum.repos.d/{{item}}"
+  with_items:
+    - "elrepo.repo"
+  when: kvm_install_elrepo_kernel
+  tags:
+    - kvm
+
+- name: Install ELrepo kernel
+  shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }}"
+  when: kvm_install_elrepo_kernel
+  tags:
+    - kvm

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -22,7 +22,6 @@
   setup:
     gather_subset:
       - '!all'
-      - '!any'
       - facter
 
 - debug: msg "OS release is {{ ansible_distribution }} and major version is {{ ansible_distribution_major_version}}"

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -17,8 +17,8 @@
 # Unauthorized copying of this file, via any medium is strictly prohibited
 # Proprietary and confidential
 # Released by ShapeBlue <info@shapeblue.com>, April 2014
-  ---
-  gather_facts: true
+---
+gather_facts: true
 
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
@@ -26,7 +26,7 @@
 - name: Install ELrepo kernel
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
 
-- name: ###### print out operating system ######
+- name: print out operating system
 - debug: var=ansible_distribution
 
 - name: Set ELrepo kernel as the default (CentOS 6)

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -19,9 +19,8 @@
 # Released by ShapeBlue <info@shapeblue.com>, April 2014
 
 - name: Setup ELrepo-kernel yum repository
-  template: src="{{ inventory_dir }}/templates/{{ item }}.j2" dest="/etc/yum.repos.d/{{item}}"
-  with_items:
-    - "elrepo.repo"
+  template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
+ 
  
 - name: Install ELrepo kernel
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -20,8 +20,7 @@
 
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
- 
- 
+    
 - name: Install ELrepo kernel
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
   

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -1,0 +1,45 @@
+---
+
+#Copyright 2016 ShapeBlue
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+# Copyright (C) ShapeBlue Ltd - All Rights Reserved
+# Unauthorized copying of this file, via any medium is strictly prohibited
+# Proprietary and confidential
+# Released by ShapeBlue <info@shapeblue.com>, April 2014
+
+- name: Setup ELrepo-kernel yum repository
+  template: src="{{ inventory_dir }}/templates/{{ item }}.j2" dest="/etc/yum.repos.d/{{item}}"
+  with_items:
+    - "elrepo.repo"
+ 
+- name: Install ELrepo kernel
+  shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
+  
+- name: Set ELrepo kernel as the default (CentOS 6)
+  shell: sed -i '/default=1/c\default=0' /boot/grub/grub.conf
+  when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "6")
+
+- name: Set ELrepo kernel as the default one (CentOS 7)
+  shell: grub2-set-default 0
+  when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "7")
+
+- name: Reboot KVM host to load ELrepo kernel
+  shell: /sbin/reboot
+  async: 0
+  poll: 0
+  ignore_errors: true	
+	
+- name: wait for ssh
+  local_action: wait_for port=22 host="{{ ansible_ssh_host }}" timeout={{ ssh_retries }} connect_timeout=5
+  when: (not use_phys_hosts)

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -21,8 +21,6 @@
 - name: Now I'm connected, get facts
   setup:
 
-- debug: msg "OS release is {{ ansible_distribution }} and major version is {{ ansible_distribution_major_version}}"
-
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
 

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -38,8 +38,8 @@
   shell: /sbin/reboot
   async: 0
   poll: 0
-  ignore_errors: true	
-	
+  ignore_errors: true
+
 - name: wait for ssh
   local_action: wait_for port=22 host="{{ ansible_ssh_host }}" timeout={{ ssh_retries }} connect_timeout=5
   when: (not use_phys_hosts)

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -18,7 +18,12 @@
 # Proprietary and confidential
 # Released by ShapeBlue <info@shapeblue.com>, April 2014
 
-gather_facts: true
+- name: Collect only facts returned by facter
+  setup:
+    gather_subset:
+      - '!all'
+      - '!any'
+      - facter
 
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
@@ -27,7 +32,7 @@ gather_facts: true
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
 
 - name: print out operating system
-- debug: var=ansible_distribution
+- debug: msg "OS release is {{ ansible_distribution }} and major version is {{ ansible_distribution_major_version}}"
 
 - name: Set ELrepo kernel as the default (CentOS 6)
   shell: sed -i '/default=1/c\default=0' /boot/grub/grub.conf

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -17,7 +17,7 @@
 # Unauthorized copying of this file, via any medium is strictly prohibited
 # Proprietary and confidential
 # Released by ShapeBlue <info@shapeblue.com>, April 2014
----
+
 gather_facts: true
 
 - name: Setup ELrepo-kernel yum repository

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -20,10 +20,15 @@
 
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
-    
+
 - name: Install ELrepo kernel
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
-  
+
+- name: ###### print out operating system ######
+  gather_facts: True
+  tasks:
+  - debug: var=ansible_distribution
+
 - name: Set ELrepo kernel as the default (CentOS 6)
   shell: sed -i '/default=1/c\default=0' /boot/grub/grub.conf
   when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "6")

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -25,14 +25,13 @@
       - '!any'
       - facter
 
+- debug: msg "OS release is {{ ansible_distribution }} and major version is {{ ansible_distribution_major_version}}"
+
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
 
 - name: Install ELrepo kernel
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
-
-- name: print out operating system
-- debug: msg "OS release is {{ ansible_distribution }} and major version is {{ ansible_distribution_major_version}}"
 
 - name: Set ELrepo kernel as the default (CentOS 6)
   shell: sed -i '/default=1/c\default=0' /boot/grub/grub.conf

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -18,11 +18,8 @@
 # Proprietary and confidential
 # Released by ShapeBlue <info@shapeblue.com>, April 2014
 
-- name: Collect only facts returned by facter
+- name: Now I'm connected, get facts
   setup:
-    gather_subset:
-      - '!all'
-      - facter
 
 - debug: msg "OS release is {{ ansible_distribution }} and major version is {{ ansible_distribution_major_version}}"
 
@@ -34,11 +31,11 @@
 
 - name: Set ELrepo kernel as the default (CentOS 6)
   shell: sed -i '/default=1/c\default=0' /boot/grub/grub.conf
-  when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "6")
+  when: (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux') and (ansible_distribution_major_version == "6")
 
 - name: Set ELrepo kernel as the default one (CentOS 7)
   shell: grub2-set-default 0
-  when: (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == "7")
+  when: (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux') and (ansible_distribution_major_version == "7")
 
 - name: Reboot KVM host to load ELrepo kernel
   shell: /sbin/reboot

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -17,6 +17,8 @@
 # Unauthorized copying of this file, via any medium is strictly prohibited
 # Proprietary and confidential
 # Released by ShapeBlue <info@shapeblue.com>, April 2014
+  ---
+  gather_facts: true
 
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
@@ -25,9 +27,7 @@
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
 
 - name: ###### print out operating system ######
-  gather_facts: True
-  tasks:
-  - debug: var=ansible_distribution
+- debug: var=ansible_distribution
 
 - name: Set ELrepo kernel as the default (CentOS 6)
   shell: sed -i '/default=1/c\default=0' /boot/grub/grub.conf

--- a/Ansible/roles/kvm/templates/elrepo.repo.j2
+++ b/Ansible/roles/kvm/templates/elrepo.repo.j2
@@ -1,3 +1,4 @@
+---
 
 #Copyright 2016 ShapeBlue
 #
@@ -14,7 +15,7 @@
 #limitations under the License.
 
 
-# Set elrepo release based on kvm_os
+#Set elrepo release based on kvm_os
 {% if kvm_os | lower == "6" %}
 {% set el_os = "el6" %}
 {% elif kvm_os | lower == "62" %}

--- a/Ansible/roles/kvm/templates/elrepo.repo.j2
+++ b/Ansible/roles/kvm/templates/elrepo.repo.j2
@@ -1,5 +1,3 @@
----
-
 #Copyright 2016 ShapeBlue
 #
 #Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,28 +12,14 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 
-
-#Set elrepo release based on kvm_os
-{% if kvm_os | lower == "6" %}
-{% set el_os = "el6" %}
-{% elif kvm_os | lower == "62" %}
-{% set el_os = "el6" %}
-{% elif kvm_os | lower == "64" %}
-{% set el_os = "el6" %}
-{% elif kvm_os | lower == "73" %}
-{% set el_os = "el7" %}
-{% elif kvm_os | lower == "7" %}
-{% set el_os = "el7" %}
-{% endif %}
-
 [elrepo-kernel]
-name=ELRepo.org Community Enterprise Linux Kernel Repository - {{ el_os }}
-baseurl=http://elrepo.org/linux/kernel/{{ el_os }}/$basearch/
-        http://mirrors.coreix.net/elrepo/kernel/{{ el_os }}/$basearch/
-        http://mirror.rackspace.com/elrepo/kernel/{{ el_os }}/$basearch/
-        http://repos.lax-noc.com/elrepo/kernel/{{ el_os }}/$basearch/
-        http://mirror.ventraip.net.au/elrepo/kernel/{{ el_os }}/$basearch/
-mirrorlist=http://mirrors.elrepo.org/mirrors-elrepo-kernel.{{ el_os }}
+name=ELRepo.org Community Enterprise Linux Kernel Repository
+baseurl=http://elrepo.org/linux/kernel/el$releasever/$basearch/
+        http://mirrors.coreix.net/elrepo/kernel/el$releasever/$basearch/
+        http://mirror.rackspace.com/elrepo/kernel/el$releasever/$basearch/
+        http://repos.lax-noc.com/elrepo/kernel/el$releasever/$basearch/
+        http://mirror.ventraip.net.au/elrepo/kernel/el$releasever/$basearch/
+mirrorlist=http://mirrors.elrepo.org/mirrors-elrepo-kernel.el$releasever
 enabled=0
 gpgcheck=0
 protect=0

--- a/Ansible/roles/kvm/templates/elrepo.repo.j2
+++ b/Ansible/roles/kvm/templates/elrepo.repo.j2
@@ -25,7 +25,7 @@
 {% set el_os = "el7" %}
 {% elif kvm_os | lower == "7" %}
 {% set el_os = "el7" %}
-
+{% endif %}
 
 [elrepo-kernel]
 name=ELRepo.org Community Enterprise Linux Kernel Repository - {{ el_os }}

--- a/Ansible/roles/kvm/templates/elrepo.repo.j2
+++ b/Ansible/roles/kvm/templates/elrepo.repo.j2
@@ -1,0 +1,40 @@
+
+#Copyright 2016 ShapeBlue
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+
+# Set elrepo release based on kvm_os
+{% if kvm_os | lower == "6" %}
+{% set el_os = "el6" %}
+{% elif kvm_os | lower == "62" %}
+{% set el_os = "el6" %}
+{% elif kvm_os | lower == "64" %}
+{% set el_os = "el6" %}
+{% elif kvm_os | lower == "73" %}
+{% set el_os = "el7" %}
+{% elif kvm_os | lower == "7" %}
+{% set el_os = "el7" %}
+
+
+[elrepo-kernel]
+name=ELRepo.org Community Enterprise Linux Kernel Repository - {{ el_os }}
+baseurl=http://elrepo.org/linux/kernel/{{ el_os }}/$basearch/
+        http://mirrors.coreix.net/elrepo/kernel/{{ el_os }}/$basearch/
+        http://mirror.rackspace.com/elrepo/kernel/{{ el_os }}/$basearch/
+        http://repos.lax-noc.com/elrepo/kernel/{{ el_os }}/$basearch/
+        http://mirror.ventraip.net.au/elrepo/kernel/{{ el_os }}/$basearch/
+mirrorlist=http://mirrors.elrepo.org/mirrors-elrepo-kernel.{{ el_os }}
+enabled=0
+gpgcheck=0
+protect=0

--- a/Ansible/templates/nestedgroupvars.j2
+++ b/Ansible/templates/nestedgroupvars.j2
@@ -376,6 +376,8 @@ kvm_localstorage_mount: "{{ kvm_localstorage_mount | default( def_kvm_localstora
 phys_host_mgmt_if: "{{ phys_host_mgmt_if | default( def_phys_host_mgmt_if ) }}"
 phys_host_trunked_if: "{{ phys_host_trunked_if | default( def_phys_host_trunked_if ) }}"
 phys_host_PXE_if: "{{ phys_host_PXE_if | default( def_phys_host_PXE_if ) }}"
+kvm_install_elrepo_kernel: {{ kvm_install_elrepo_kernel | default( def_kvm_install_elrepo_kernel) }}
+kvm_elrepo_kernel_version: "{{ kvm_elrepo_kernel_version| default( def_kvm_elrepo_kernel_version ) }}"
 
 # XS
 xs_ver: "{{ xs_ver }}"

--- a/Ansible/upgrade_env.yaml
+++ b/Ansible/upgrade_env.yaml
@@ -167,7 +167,7 @@
     shell: "curl http://127.0.0.1:8080/client/api --connect-timeout 5"
     register: result
     until: result.stdout.find("unable to verify user") != -1
-    retries: 50
+    retries: 100
     run_once: true
 
   - name: determine number of db hosts


### PR DESCRIPTION
Support install of ELrepo kernel on CentOS 6/7 (kernel-lt, kernel-ml, or any custom versions available in that repo).

