### PR TITLE
Update smoketests.sh.j2

### DIFF
--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -31,7 +31,7 @@ fi
 
 STUCKTEMPLATES=0
 STUCKVMS=0
-STUCKNETORKS=0
+STUCKNETWORKS=0
 STUCKVPCS=0
 STUCKVOLS=0
 sleepduration=10
@@ -42,6 +42,19 @@ rm -f $TESTDIR/test_*.pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/*pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/config/*pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/lib/*pyc
+rm -f $CLEAN_UP_LOG
+
+cmk list accounts listall=true name="baremetal-system-account" | jq -r '.account[] .id'  > .skipdeletingaccounts
+cmk list accounts listall=true name="ACSuser" | jq -r '.account[] .id'  >> .skipdeletingaccounts
+cmk list accounts listall=true name="admin" | jq -r '.account[] .id'  >> .skipdeletingaccounts
+cmk list serviceofferings listall=true issystem=false name='medium instance' | jq -r '.serviceoffering[].id' > .skipdeleteofferings
+cmk list serviceofferings listall=true issystem=false name='small instance' | jq -r '.serviceoffering[].id' >> .skipdeleteofferings
+cmk list diskofferings listall=true issystem=false name='small' | jq -r '.diskoffering[].id' > .skipdeletediskofferings
+cmk list diskofferings listall=true issystem=false name='medium' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
+cmk list diskofferings listall=true issystem=false name='large' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
+cmk list diskofferings listall=true issystem=false name='custom' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
+cmk list domains listall=true name="root" | jq -r '.domain[].id' > skipdeletingdomains
+touch $CLEAN_UP_LOG
 
 cleanup() {
   # dont wait for async job - execute in parallel until told otherwise
@@ -50,28 +63,26 @@ cleanup() {
   # TODO: N/A
 
   echo "Destroy alerts"
-  for id in $(cloudmonkey list alerts listall=true keyword=vm filter=id | jq -r '.alert[] .id'); do
+  for id in $(cmk list alerts listall=true keyword=vm | jq -r '.alert[] .id'); do
     cloudmonkey delete alerts ids=$id || true
   done
 
   echo "Destroy templates, forced, since some VMs might exist."
-  GCTEMPLATES=`cmk list templates templatefilter=self listall=true`
-  NUM_GCTEMPLATES=`echo $GCTEMPLATES | jq -r '.count'`
-  if [ $NUM_GCTEMPLATES -gt $STUCKTEMPLATES ]; then
-    echo "Test file $file left behind $NUM_GCTEMPLATES templates" >> $CLEAN_UP_LOG
-    for templateid in $(echo $GCTEMPLATES | jq -r '.template[] .id'); do
+  NUM_GCTEMPLATES=`cmk list templates templatefilter=self listall=true | jq -r '.template[] | length'`
+  if [[ $NUM_GCTEMPLATES -gt $STUCKTEMPLATES ]]; then
+    echo "Test file $file left behind $(($NUM_GCTEMPLATES-$STUCKTEMPLATES)) templates" >> $CLEAN_UP_LOG
+    for templateid in $(echo $GCTEMPLATES | jq -r '.template[].id'); do
       cmk delete template id=$templateid forced=true  || true
     done
-  sleep $sleepduration
-  STUCKTEMPLATES=`cmk list templates templatefilter=self | jq -r '.count'`
+    sleep $((sleepduration)*2)
+    STUCKTEMPLATES=`cmk list templates templatefilter=self | jq -r '.template[] | length'`
   fi
 
   echo "Destroy vms, all in parallel"
-  GCVMS=`cmk list virtualmachines listall=true filter=id`
-  NUM_GCVMS=`echo $GCVMS | jq -r '.count'`
-  if [ $NUM_GCVMS -gt $STUCKVMS ]; then
-    echo "Test file $file left behind $NUM_GCVMS VMs" >> $CLEAN_UP_LOG
-    for vmid in $(echo $GCVMS | jq -r '.virtualmachine[] .id'); do
+  NUM_GCVMS=`cmk list virtualmachines listall=true $GCVMS | jq -r '.count'`
+  if [[ $NUM_GCVMS -gt $STUCKVMS ]]; then
+    echo "Test file $file left behind $(($NUM_GCVMS-$STUCKVMS)) VMs" >> $CLEAN_UP_LOG
+    for vmid in $(cmk list virtualmachines listall=true $GCVMS | jq -r '.virtualmachine[].id'); do
       cmk destroy virtualmachine id=$vmid expunge=true || true
     done
     echo "wait ${sleepduration}s to give VMs some time to be destroyed"
@@ -81,9 +92,9 @@ cleanup() {
   tries=$retries
   while [ $tries -gt 0 ]     
   do 
-    NUM_GCVMS=`cmk list virtualmachines listall=true| jq -r '.count'`
-    if [ $NUM_GCVMS -gt $STUCKVMS ]; then
-      echo "Still $NUM_GCVMS left"
+    NUM_GCVMS=`cmk list virtualmachines listall=true| jq -r '.virtualmachine[] | length'`
+    if [[ $NUM_GCVMS -gt $STUCKVMS ]]; then
+      echo "Still $NUM_GCVMS left. waiting.."
       sleep $sleepduration
       tries=$((tries)-1)
       if [ retries -eq 0 ]; then STUCKVMS=$NUM_GCVMS; fi
@@ -92,123 +103,103 @@ cleanup() {
     fi
   done
 
-    # Not neeed to destroy VRs explicitely, will be destroyed with network/VPC - otherwise later deleting network/VPC fails if VR is gone!!!
-
-# then move on and hope for the best; i.e. 60secs (total of 300sec waiting time)
-
   tries=$retries
-  echo "deleting netowrks"
-  GCNETWORKS=$(cmk list networks listall=true filter=id | jq -r '.network[] .id')
-  NUM_GCNETWORKS=`echo $GCNETWORKS | jq '.count'`
-  if [ $NUM_GCNETWORKS -gt $STUCKNETWORKS ]; then
-    echo "Test file $file left behind $NUM_GCNETWORKS Networks" >> $CLEAN_UP_LOG    
+  echo "deleting networks"
+  NUM_GCNETWORKS=`cmk list networks listall=true | jq -r '.network[] | length'`
+  if [[ $NUM_GCNETWORKS -gt $STUCKNETWORKS ]]; then
+    echo "Test file $file left $(($NUM_GCNETWORKS-$STUCKNETWORKS)) Networks behind" >> $CLEAN_UP_LOG    
     while [ $tries -gt 0 ]     
     do 
-      for netid in $(cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'); do
+      for netid in $(cmk list networks listall=true | jq -r '.network[].id'); do
         cmk delete network id=$netid || true
       done
     echo "wait ${sleepduration}s to give Networks some time to destroy"
     sleep $sleepduration
-    NUM_GCNETWORKS=`cmk networks listall=true filter=id | jq -r '.count'`
-    if [ $NUM_GCNETWORKS -gt $STUCKVMS ]; then
+    NUM_GCNETWORKS=`cmk networks listall=true | jq -r '.count'`
+    if [[ $NUM_GCNETWORKS -gt $STUCKVMS ]]; then
       tries=$((retries)-1)
-      if [ retries -eq 0 ]; then STUCKNETWORKS=$NUM_GCNETWORKS; fi
     else
       tries=0
     fi
     done
-  fi   
-
+    STUCKNETWORKS=$NUM_GCNETWORKS
+  fi
+ 
+  tries=$retries
   echo "deleting VPCs"
-  GCVPCS=$(cmk list vpcs listall=true filter=id | jq -r '.vpc[] .id')
-  NUM_GCVPCS=`echo $VPCs | jq '.VPC | length'`
-  if [ $NUM_GCVPC -gt $STUCKVPCS ]; then
-    echo "$file left $NUM_GCVPCS behind"
-    for vid in $(cmk list vpcs listall=true | jq -r '.vpc[] .id'); do
-      cmk delete vpc id=$vid || true
-    done
-    sleep $sleepduration
-    NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.count'`
-    if [ $NUM_GCVPCS -gt $STUCKVPCS ]; then
-      tries=$((retries)-1)
-      if [ retries -eq 0 ]; then
-        STUCKVPCS=$NUM_GCVPCS
+  NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.vpc[] | length'`
+  if [[ $NUM_GCVPC -gt $STUCKVPCS ]]; then
+    echo "Test $file left $(($NUM_GCVPCS-$STUCKVPCS)) VPCs behind" >> $CLEAN_UP_LOG
+    while [ $tries -gt 0 ]; do
+      for vid in $(cmk list vpcs listall=true | jq -r '.vpc[].id'); do
+        cmk delete vpc id=$vid || true
+      done
+      sleep $sleepduration
+      NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.count'`
+      if [ $NUM_GCVPCS -gt $STUCKVPCS ]; then
+        tries=$((retries)-1)
       else
-        sleep $sleepduration
+        tries=0
       fi
-    else
-      tries=0
-    fi
     done
+  STUCKVPCS=$NUM_GCVPCS
   fi
 
   # move to blocking async calls (just volume deletion, should be very fast), so later we can delete accounts and domains
   cloudmonkey set asyncblock true
 
   # Destroy data volumes when zero attached (all VMs deleted)
-  NUM_GCVOLS=$(cmk list volumes type=data | jq -r '.count')
-  if [ $NUM_GCVOLS -gt $STUCKVOLS ]; then
+  NUM_GCVOLS=$(cmk list volumes type=data | jq -r '.volume[] | length')
+  if [[ $NUM_GCVOLS -gt $STUCKVOLS ]]; then
+    echo "$file left $(($NUM_GCVOLS-$STUCKVOLS)) volumes behind" >> $CLEAN_UP_LOG
     for volumeid in $(cmk list volumes listall=true type=data | jq -r '.volume[] .id'); do
       cmk delete volume id=$volumeid || true
     done
-  fi
-  sleep $sleepduration
-  NUM_GCVOLS=`cmk list volumes listall=true type=data | jq -r '.count'`
-  if [ $NUM_GCVOLS -gt $STUCKVOLS ]; then
-    tries=$((retries)-1)
-    if [ retries -eq 0 ]; then
-      STUCKVOLS=$NUM_GCVOLS
-    else
-      sleep $sleepduration
-    fi
-  else
-    tries=0
-  fi
-  done
+    sleep $sleepduration
+  NUM_GCVOLS=`cmk list volumes listall=true type=data | jq -r '.volume[] | length'`
+  STUCKVOLS=$NUM_GCVOLS
   fi
 
   # Destroy accounts (keep some, delete all others)
-  cmk list accounts listall=true filter=id name="baremetal-system-account" | jq -r '.account[] .id'  > .skipdeletingaccounts
-  cmk list accounts listall=true filter=id name="ACSuser" | jq -r '.account[] .id'  >> .skipdeletingaccounts
-  cmk list accounts listall=true filter=id name="admin" | jq -r '.account[] .id'  >> .skipdeletingaccounts
-  cmk list accounts listall=true filter=id | jq -r '.account[] .id'  > .deleteaccounts
-  for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
-    cmk delete account id=$accountid || true
-  done
+  cmk list accounts listall=true | jq -r '.account[] .id'  > .deleteaccounts
+  NUM_LEFT=`cat .deleteaccounts | wc -l`
+  if [[ $NUM_LEFT -gt 0 ]]; then
+    echo "$file left $NUM_LEFT accounts behind"
+    for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
+      cmk delete account id=$accountid || true
+    done
+  fi 
 
   # Destroy domains (keep ROOT domain, delete all other)
-  cmk list domains listall=true filter=id name=ROOT | jq -r '.domain[] .id' > .skipdeletingdomains
-  cmk list domains listall=true filter=id | jq -r '.domain[] .id' > .deletedomains
-  for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
-    cmk delete domain id=$domainid || true
-  done
-  
-  cmk list serviceofferings listall=true issystem=false name='medium instance' | jq -r '.serviceoffering[].id' > .skipdeleteofferings
-  cmk list serviceofferings listall=true issystem=false name='small instance' | jq -r '.serviceoffering[].id' >> .skipdeleteofferings
+  cmk list domains listall=true | jq -r '.domain[] .id' > .deletedomains
+  NUM_LEFT=`cat .deletedomains | wc -l`
+  if [[ $NUM_LEFT -gt 0 ]]; then
+    for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
+      cmk delete domain id=$domainid || true
+    done
+  fi
+
   cmk list serviceofferings listall=true issystem=false | jq -r '.serviceoffering[].id' > .deleteofferings
-  for offeringid in $(comm -13 <(sort -u .skipdeletdeleteofferings) <(sort -u .deleteofferings)); do
-    cmk delete serviceofferings id=$offeringid || true
-  done
+  NUM_LEFT=`cat .deleteofferings | wc -l`
+  if [[ $NUM_LEFT -gt 0 ]]; then
+    for offeringid in $(comm -13 <(sort -u .skipdeleteofferings) <(sort -u .deleteofferings)); do
+      cmk delete serviceofferings id=$offeringid || true
+    done
+  fi
 
-  cmk list diskofferings listall=true issystem=false name='small' | jq -r '.diskoffering[].id' > .skipdeletediskofferings
-  cmk list diskofferings listall=true issystem=false name='medium' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
-  cmk list diskofferings listall=true issystem=false name='large' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
-  cmk list diskofferings listall=true issystem=false name='custom' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
   cmk list diskofferings listall=true issystem=false | jq -r '.diskoffering[].id' > .deletediskofferings
-  for offeringid in $(comm -13 <(sort -u .skipdeletediskofferings) <(sort -u .deletediskofferings)); do
-    cmk delete diskofferings id=$offeringid || true
-  done
+  NUM_LEFT=`cat .deletediskofferings | wc -l `
+  if [[ $NUM_LEFT -gt 0 ]]; then
+    for offeringid in $(comm -13 <(sort -u .skipdeletediskofferings) <(sort -u .deletediskofferings)); do
+      cmk delete diskofferings id=$offeringid || true
+    done
+  fi
 
+# cleanup 
 
-
-# cleanup
-rm -f .skipdeletingaccounts
 rm -f .deleteaccounts
-rm -f .skipdeletingdomain
 rm -f .deletedomain
-rm -f .skipdeleteofferings
 rm -f .deleteofferings
-rm -f .skipdeletediskofferings
 rm -f .deletediskofferings
 }
 
@@ -287,6 +278,12 @@ for file in $FILES; do
   counter=$((counter+1))
 
 done
+
+rm -f .skipdeletingaccounts
+rm -f .skipdeletingdomain
+rm -f .skipdeleteofferings
+rm -f .skipdeletediskofferings
+
 
 GOOD=0
 BAD=0

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -188,7 +188,7 @@ cleanup() {
   cmk list serviceofferings listall=true issystem=false | jq -r '.serviceoffering[].id' > .deleteofferings
   NUM_LEFT=`cat .deleteofferings | wc -l`
   if [[ $NUM_LEFT -gt 2 ]]; then
-    echo "$(basename $file) left behind $(($NUM_LEFT-3)) service offerings" >> $CLEAN_UP_LOG
+    echo "$(basename $file) left behind $(($NUM_LEFT-2)) service offerings" >> $CLEAN_UP_LOG
     for offeringid in $(comm -13 <(sort -u .skipdeleteofferings) <(sort -u .deleteofferings)); do
       cmk delete serviceoffering id=$offeringid || true
     done

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -29,154 +29,207 @@ else
   jenkinslink=""
 fi
 
+STUCKTEMPLATES=0
+STUCKVMS=0
+STUCKNETORKS=0
+STUCKVPCS=0
+STUCKVOLS=0
+sleepduration=10
+retries=12
+
 rm -f /marvin/smoketests-summary.txt
 rm -f $TESTDIR/test_*.pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/*pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/config/*pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/lib/*pyc
 
-count_networks() {
-  GCNETWORKS=`cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'`
-  NUM_GCNETWORKS=`echo $GCNETWORKS | jq '.network | length'`
-}
-
 cleanup() {
-    # dont wait for async job - execute in parallel until told otherwise
-    cloudmonkey set asyncblock false
-    cloudmonkey set output json
-    # TODO: N/A
+  # dont wait for async job - execute in parallel until told otherwise
+  cloudmonkey set asyncblock false
+  cloudmonkey set output json
+  # TODO: N/A
 
-    echo "Destroy alerts"
-    for id in $(cloudmonkey list alerts listall=true keyword=vm filter=id | jq -r '.alert[] .id'); do
-        cloudmonkey delete alerts ids=$id || true
+  echo "Destroy alerts"
+  for id in $(cloudmonkey list alerts listall=true keyword=vm filter=id | jq -r '.alert[] .id'); do
+    cloudmonkey delete alerts ids=$id || true
+  done
+
+  echo "Destroy templates, forced, since some VMs might exist."
+  GCTEMPLATES=`cmk list templates templatefilter=self listall=true`
+  NUM_GCTEMPLATES=`echo $GCTEMPLATES | jq -r '.count'`
+  if [ $NUM_GCTEMPLATES -gt $STUCKTEMPLATES ]; then
+    echo "Test file $file left behind $NUM_GCTEMPLATES templates" >> $CLEAN_UP_LOG
+    for templateid in $(echo $GCTEMPLATES | jq -r '.template[] .id'); do
+      cmk delete template id=$templateid forced=true  || true
     done
+  sleep $sleepduration
+  STUCKTEMPLATES=`cmk list templates templatefilter=self | jq -r '.count'`
+  fi
 
-    echo "Destroy templates, forced, since some VMs might exist."
-    GCTEMPLATES=`cmk list templates templatefilter=self`
-    NUM_GCTEMPLATES=`echo $GCTEMPLATES | jq '.template | length'`
-    if [ $NUM_GCTEMPLATES -gt 0 ]; then
-      echo "Test file $file left behind $NUM_GCTEMPLATES templates" >> $CLEAN_UP_LOG
-      for templateid in $(echo $GCTEMPLATES | jq -r '.template[] .id'); do
-          cloudmonkey delete template id=$templateid forced=true  || true
-      done
-    fi
+  echo "Destroy vms, all in parallel"
+  GCVMS=`cmk list virtualmachines listall=true filter=id`
+  NUM_GCVMS=`echo $GCVMS | jq -r '.count'`
+  if [ $NUM_GCVMS -gt $STUCKVMS ]; then
+    echo "Test file $file left behind $NUM_GCVMS VMs" >> $CLEAN_UP_LOG
+    for vmid in $(echo $GCVMS | jq -r '.virtualmachine[] .id'); do
+      cmk destroy virtualmachine id=$vmid expunge=true || true
+    done
+    echo "wait ${sleepduration}s to give VMs some time to be destroyed"
+    sleep $sleepduration
+  fi
 
-  sleepduration=10
-
-    echo "Destroy vms, all in parallel"
-    GCVMS=`cmk list virtualmachines listall=true filter=id`
-    NUM_GCVMS=`echo $GCVMS | jq '.virtualmachine | length'`
-    if [ $NUM_GCVMS -gt 0 ]; then
-      echo "Test file $file left behind $NUM_GCVMS VMs" >> $CLEAN_UP_LOG
-      for vmid in $(echo $GCVMS | jq -r '.virtualmachine[] .id'); do
-          cloudmonkey destroy virtualmachine id=$vmid expunge=true || true
-      done
-      echo "wait ${sleepduration}s to give VM destory some time"
+  tries=$retries
+  while [ $tries -gt 0 ]     
+  do 
+    NUM_GCVMS=`cmk list virtualmachines listall=true| jq -r '.count'`
+    if [ $NUM_GCVMS -gt $STUCKVMS ]; then
+      echo "Still $NUM_GCVMS left"
       sleep $sleepduration
+      tries=$((tries)-1)
+      if [ retries -eq 0 ]; then STUCKVMS=$NUM_GCVMS; fi
+    else
+      tries=0
     fi
+  done
 
     # Not neeed to destroy VRs explicitely, will be destroyed with network/VPC - otherwise later deleting network/VPC fails if VR is gone!!!
 
-# Set sleep time (seconds) between checks if child resources deleted; i.e. 5secs
-  sleepduration=10
-# Set max number of retires after the sleep period - i.e. if child resource is not deleted withing $sleepduration x $maxretries,
 # then move on and hope for the best; i.e. 60secs (total of 300sec waiting time)
-  retries=60
-  
+
+  tries=$retries
   echo "deleting netowrks"
-  count_networks
-  if [ $NUM_GCNETWORKS -gt 0 ]; then
+  GCNETWORKS=$(cmk list networks listall=true filter=id | jq -r '.network[] .id')
+  NUM_GCNETWORKS=`echo $GCNETWORKS | jq '.count'`
+  if [ $NUM_GCNETWORKS -gt $STUCKNETWORKS ]; then
     echo "Test file $file left behind $NUM_GCNETWORKS Networks" >> $CLEAN_UP_LOG    
-    while [ $retries -gt 0 ]     
+    while [ $tries -gt 0 ]     
     do 
       for netid in $(cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'); do
-        cloudmonkey delete network id=$netid || true
+        cmk delete network id=$netid || true
       done
     echo "wait ${sleepduration}s to give Networks some time to destroy"
     sleep $sleepduration
-    count_networks
-    if [ $NUM_GCNETWORKS -gt 0 ]; then
-      retries=$((retries)-1)
+    NUM_GCNETWORKS=`cmk networks listall=true filter=id | jq -r '.count'`
+    if [ $NUM_GCNETWORKS -gt $STUCKVMS ]; then
+      tries=$((retries)-1)
+      if [ retries -eq 0 ]; then STUCKNETWORKS=$NUM_GCNETWORKS; fi
     else
-      retries=0
+      tries=0
     fi
     done
   fi   
 
   echo "deleting VPCs"
-  GCVPCS=`cloudmonkey list vpcs listall=true filter=id | jq -r '.vpc[] .id'`
+  GCVPCS=$(cmk list vpcs listall=true filter=id | jq -r '.vpc[] .id')
   NUM_GCVPCS=`echo $VPCs | jq '.VPC | length'`
-  if [ $NUM_GCVPC -gt 0 ]; then
+  if [ $NUM_GCVPC -gt $STUCKVPCS ]; then
     echo "$file left $NUM_GCVPCS behind"
-    for vid in $(cloudmonkey list vpcs listall=true filter=id | jq -r '.vpc[] .id'); do
-        cloudmonkey delete vpc id=$vid || true
+    for vid in $(cmk list vpcs listall=true | jq -r '.vpc[] .id'); do
+      cmk delete vpc id=$vid || true
     done
-
-    # move to blocking async calls (just volume deletion, should be very fast), so later we can delete accounts and domains
-    cloudmonkey set asyncblock true
-
-    # Destroy data volumes when zero attached (all VMs deleted)
-        NumAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
-        retries=0
-        while [ $NumAttachedVolumes -ne 0 ]
-       do
-          echo "Retrying in $sleepduration sec"
-          sleep $sleepduration
-             if [[ "$NumAttachedVolumes" == '0' ]]; then
-                echo "No more VMs, about to wipe all DATA Volumes..."
-                break
-             fi
-             if [[ "$retries" == "$maxretries" ]]; then
-                echo "Waited for some time, giving up, trying wiping VPCs..."
-                break
-             fi
-           NumAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
-           (( retries++ ))
-         done
-    for volumeid in $(cloudmonkey list volumes listall=true type=data filter=id | jq -r '.volume[] .id'); do
-        cloudmonkey delete volume id=$volumeid || true
+    sleep $sleepduration
+    NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.count'`
+    if [ $NUM_GCVPCS -gt $STUCKVPCS ]; then
+      tries=$((retries)-1)
+      if [ retries -eq 0 ]; then
+        STUCKVPCS=$NUM_GCVPCS
+      else
+        sleep $sleepduration
+      fi
+    else
+      tries=0
+    fi
     done
+  fi
 
-    # Destroy accounts (keep some, delete all others)
-    cloudmonkey list accounts listall=true filter=id name="baremetal-system-account" | jq -r '.account[] .id'  > .skipdeletingaccounts
-    cloudmonkey list accounts listall=true filter=id name="ACSuser" | jq -r '.account[] .id'  >> .skipdeletingaccounts
-    cloudmonkey list accounts listall=true filter=id name="admin" | jq -r '.account[] .id'  >> .skipdeletingaccounts
-    cloudmonkey list accounts listall=true filter=id | jq -r '.account[] .id'  > .deleteaccounts
-    for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
-        cloudmonkey delete account id=$accountid || true
-    done
+  # move to blocking async calls (just volume deletion, should be very fast), so later we can delete accounts and domains
+  cloudmonkey set asyncblock true
 
-    # Destroy domains (keep ROOT domain, delete all other)
-    cloudmonkey list domains listall=true filter=id name=ROOT | jq -r '.domain[] .id' > .skipdeletingdomains
-    cloudmonkey list domains listall=true filter=id | jq -r '.domain[] .id' > .deletedomains
-    for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
-        cloudmonkey delete domain id=$domainid || true
+  # Destroy data volumes when zero attached (all VMs deleted)
+  NUM_GCVOLS=$(cmk list volumes type=data | jq -r '.count')
+  if [ $NUM_GCVOLS -gt $STUCKVOLS ]; then
+    for volumeid in $(cmk list volumes listall=true type=data | jq -r '.volume[] .id'); do
+      cmk delete volume id=$volumeid || true
     done
+  fi
+  sleep $sleepduration
+  NUM_GCVOLS=`cmk list volumes listall=true type=data | jq -r '.count'`
+  if [ $NUM_GCVOLS -gt $STUCKVOLS ]; then
+    tries=$((retries)-1)
+    if [ retries -eq 0 ]; then
+      STUCKVOLS=$NUM_GCVOLS
+    else
+      sleep $sleepduration
+    fi
+  else
+    tries=0
+  fi
+  done
+  fi
+
+  # Destroy accounts (keep some, delete all others)
+  cmk list accounts listall=true filter=id name="baremetal-system-account" | jq -r '.account[] .id'  > .skipdeletingaccounts
+  cmk list accounts listall=true filter=id name="ACSuser" | jq -r '.account[] .id'  >> .skipdeletingaccounts
+  cmk list accounts listall=true filter=id name="admin" | jq -r '.account[] .id'  >> .skipdeletingaccounts
+  cmk list accounts listall=true filter=id | jq -r '.account[] .id'  > .deleteaccounts
+  for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
+    cmk delete account id=$accountid || true
+  done
+
+  # Destroy domains (keep ROOT domain, delete all other)
+  cmk list domains listall=true filter=id name=ROOT | jq -r '.domain[] .id' > .skipdeletingdomains
+  cmk list domains listall=true filter=id | jq -r '.domain[] .id' > .deletedomains
+  for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
+    cmk delete domain id=$domainid || true
+  done
+  
+  cmk list serviceofferings listall=true issystem=false name='medium instance' | jq -r '.serviceoffering[].id' > .skipdeleteofferings
+  cmk list serviceofferings listall=true issystem=false name='small instance' | jq -r '.serviceoffering[].id' >> .skipdeleteofferings
+  cmk list serviceofferings listall=true issystem=false | jq -r '.serviceoffering[].id' > .deleteofferings
+  for offeringid in $(comm -13 <(sort -u .skipdeletdeleteofferings) <(sort -u .deleteofferings)); do
+    cmk delete serviceofferings id=$offeringid || true
+  done
+
+  cmk list diskofferings listall=true issystem=false name='small' | jq -r '.diskoffering[].id' > .skipdeletediskofferings
+  cmk list diskofferings listall=true issystem=false name='medium' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
+  cmk list diskofferings listall=true issystem=false name='large' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
+  cmk list diskofferings listall=true issystem=false name='custom' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
+  cmk list diskofferings listall=true issystem=false | jq -r '.diskoffering[].id' > .deletediskofferings
+  for offeringid in $(comm -13 <(sort -u .skipdeletediskofferings) <(sort -u .deletediskofferings)); do
+    cmk delete diskofferings id=$offeringid || true
+  done
+
+
+
 # cleanup
 rm -f .skipdeletingaccounts
 rm -f .deleteaccounts
 rm -f .skipdeletingdomain
 rm -f .deletedomain
+rm -f .skipdeleteofferings
+rm -f .deleteofferings
+rm -f .skipdeletediskofferings
+rm -f .deletediskofferings
 }
 
 runtest() {
-    file=$1
-    rm -fr $LOGDIR/$(basename $file).xml
-    TRIMFILE=$(echo $(basename $file) | sed 's/.py$//g')
-    OLDRESULT=$(ls $LOGDIR | grep -E $TRIMFILE'_[a-zA-Z0-9]{6}$' | head -1)
-    if [ ! -z "${OLDRESULT// }" ]; then
-        echo "Found old test results, removing:" $LOGDIR/$OLDRESULT
-        rm -fr $LOGDIR/$OLDRESULT
-    fi
-    nosetests --with-xunit --xunit-file=$LOGDIR/$(basename $file).xml --with-json --json-file=$LOGDIR/$(basename $file).json --with-marvin --marvin-config=/marvin/{{ env_name_clean }}-advanced-cfg --hypervisor={{ env_hv }} -s -a tags={{ env_zonetype | lower }}{% if marvin_test_categories is defined %}{% for category in marvin_test_categories %},{{ category }}{% endfor %}{% endif %} $file
-    cleanup || true
+  file=$1
+  rm -fr $LOGDIR/$(basename $file).xml
+  TRIMFILE=$(echo $(basename $file) | sed 's/.py$//g')
+  OLDRESULT=$(ls $LOGDIR | grep -E $TRIMFILE'_[a-zA-Z0-9]{6}$' | head -1)
+  if [ ! -z "${OLDRESULT// }" ]; then
+    echo "Found old test results, removing:" $LOGDIR/$OLDRESULT
+    rm -fr $LOGDIR/$OLDRESULT
+  fi
+  nosetests --with-xunit --xunit-file=$LOGDIR/$(basename $file).xml --with-json --json-file=$LOGDIR/$(basename $file).json --with-marvin --marvin-config=/marvin/{{ env_name_clean }}-advanced-cfg --hypervisor={{ env_hv }} -s -a tags={{ env_zonetype | lower }}{% if marvin_test_categories is defined %}{% for category in marvin_test_categories %},{{ category }}{% endfor %}{% endif %} $file
+  cleanup || true
 }
 
 launchtest() {
-    file=$1
-    runtest $file
-    # Run tests once again on error or failure
-    python /marvin/tools/xunit-reader.py $LOGDIR/$(basename $file).xml | grep -e Failure -e Error && cleanup && runtest $file && echo "Intermittent failure detected: $file" >> /marvin/smoketests-summary.txt
+  file=$1
+  runtest $file
+  # Run tests once again on error or failure
+  python /marvin/tools/xunit-reader.py $LOGDIR/$(basename $file).xml | grep -e Failure -e Error && cleanup && runtest $file && echo "Intermittent failure detected: $file" >> /marvin/smoketests-summary.txt
 }
 slackmsg() {
    messagebody=$1
@@ -202,36 +255,36 @@ if [ -f $TESTDIR/test_hostha_kvm.py ]; then
     FILES="$FILES $TESTDIR/test_hostha_kvm.py"
 fi
 for file in $FILES; do
-    TESTFILENAME="$(basename $file)"
-    echo -e "\e[92m ---->  Starting $TESTFILENAME on {{ hostvars[groups['marvin_host'][0]]['ansible_ssh_host'] }} in: {{ env_name_clean }}\e[0m"
-    {% if use_hipchat %}    hipchat --action sendNotification --room "Marvin Notifications" --messageFormat "html" --colour "gray" --message "Starting <b>$(basename $file)</b> on {{ hostvars[groups['marvin_host'][0]]['ansible_ssh_host'] }} in: <br><b>{{ env_name_clean }}</b> - test ($counter of $NUMTESTS)"
-    {% endif %}
-    {% if use_slack %}    slackmsg "Starting $TESTFILENAME on {{ hostvars[groups['marvin_host'][0]]['ansible_ssh_host'] }}.\nTest ($counter of $NUMTESTS) " "#808080"
-    {% endif %}
-    start_time="$(date -u +%s)"
-    launchtest $file
-    end_time="$(date -u +%s)"
-    elapsed="$(($end_time-$start_time))"
-    all_tests_elapsed="$((($end_time-$run_start_time)/1440))"
-    tests_left="$(($NUMTESTS-$counter))"
-    echo "$(basename $file): $elapsed seconds" >> $LOGDIR/tests-time.txt
+  TESTFILENAME="$(basename $file)"
+  echo -e "\e[92m ---->  Starting $TESTFILENAME on {{ hostvars[groups['marvin_host'][0]]['ansible_ssh_host'] }} in: {{ env_name_clean }}\e[0m"
+  {% if use_hipchat %}    hipchat --action sendNotification --room "Marvin Notifications" --messageFormat "html" --colour "gray" --message "Starting <b>$(basename $file)</b> on {{ hostvars[groups['marvin_host'][0]]['ansible_ssh_host'] }} in: <br><b>{{ env_name_clean }}</b> - test ($counter of $NUMTESTS)"
+  {% endif %}
+  {% if use_slack %}    slackmsg "Starting $TESTFILENAME on {{ hostvars[groups['marvin_host'][0]]['ansible_ssh_host'] }}.\nTest ($counter of $NUMTESTS) " "#808080"
+  {% endif %}
+  start_time="$(date -u +%s)"
+  launchtest $file
+  end_time="$(date -u +%s)"
+  elapsed="$(($end_time-$start_time))"
+  all_tests_elapsed="$((($end_time-$run_start_time)/1440))"
+  tests_left="$(($NUMTESTS-$counter))"
+  echo "$(basename $file): $elapsed seconds" >> $LOGDIR/tests-time.txt
 
-    LASTUPDATEDIR=`ls $LOGDIR/*/ -td | head -n 1`
-    if [[ -s ${LASTUPDATEDIR}failed_plus_exceptions.txt ]]; then
-      echo "test $(basename $file) in {{ env_name_clean }} looks to have errors"
-      {% if use_hipchat %}      hipchat --action sendNotification --room "Marvin Notifications" --messageFormat "html" --colour "gray" --message "test $TESTFILENAME in {{ env_name_clean }} looks to have <span style="color:#FF0000">errors</span>. $PASSES of $counter good so far.<br>Tests have taken $all_tests_elapsed hours so far. $tests_left tests to go."
+  LASTUPDATEDIR=`ls $LOGDIR/*/ -td | head -n 1`
+  if [[ -s ${LASTUPDATEDIR}failed_plus_exceptions.txt ]]; then
+    echo "test $(basename $file) in {{ env_name_clean }} looks to have errors"
+    {% if use_hipchat %}      hipchat --action sendNotification --room "Marvin Notifications" --messageFormat "html" --colour "gray" --message "test $TESTFILENAME in {{ env_name_clean }} looks to have <span style="color:#FF0000">errors</span>. $PASSES of $counter good so far.<br>Tests have taken $all_tests_elapsed hours so far. $tests_left tests to go."
 {% endif %}
-      {% if use_slack %}      slackmsg "Test $TESTFILENAME looks to have *errors*.\n$PASSES of $counter good so far.\nTests have taken $all_tests_elapsed hours so far. $tests_left tests to go." "warning"
+    {% if use_slack %}      slackmsg "Test $TESTFILENAME looks to have *errors*.\n$PASSES of $counter good so far.\nTests have taken $all_tests_elapsed hours so far. $tests_left tests to go." "warning"
 {% endif %}
-    else
-      PASSES=$((PASSES+1))
-      echo "test $TESTFILENAME in {{ env_name_clean }} looks OK"
-      {% if use_hipchat %}       hipchat --action sendNotification --room "Marvin Notifications" --messageFormat "html" --colour "gray" --message "test $TESTFILENAME in {{ env_name_clean }} looks <span style="color:#2F962F">OK</span>. $PASSES of $counter good so far.<br>Tests have taken $all_tests_elapsed hours so far. $tests_left tests to go."
+  else
+    PASSES=$((PASSES+1))
+    echo "test $TESTFILENAME in {{ env_name_clean }} looks OK"
+    {% if use_hipchat %}       hipchat --action sendNotification --room "Marvin Notifications" --messageFormat "html" --colour "gray" --message "test $TESTFILENAME in {{ env_name_clean }} looks <span style="color:#2F962F">OK</span>. $PASSES of $counter good so far.<br>Tests have taken $all_tests_elapsed hours so far. $tests_left tests to go."
 {% endif %}
-      {% if use_slack %}      slackmsg "Test $TESTFILENAME looks *OK*.\n$PASSES of $counter good so far.\nTests have taken $all_tests_elapsed hours so far. $tests_left tests to go." "good"
+  {% if use_slack %}      slackmsg "Test $TESTFILENAME looks *OK*.\n$PASSES of $counter good so far.\nTests have taken $all_tests_elapsed hours so far. $tests_left tests to go." "good"
 {% endif %}
-    fi
-    counter=$((counter+1))
+  fi
+  counter=$((counter+1))
 
 done
 

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -19,6 +19,7 @@ TESTTYPE="Smoke tests"
 LOGDIR=/marvin/MarvinLogs
 TESTDIR="/marvin/tests/smoke"
 TMP_JSON_DIR="/marvin/json_results/"
+CLEAN_UP_LOG="$LOGDIR/cleanup.log"
 mkdir -p $LOGDIR
 echo "$(date --iso-8601=minutes)" > /marvin/testrunstartdate
 export SLACK_CLI_TOKEN="{{ slack_token }}"
@@ -34,75 +35,79 @@ rm -f /usr/lib/python2.7/site-packages/marvin/*pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/config/*pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/lib/*pyc
 
+count_networks() {
+  GCNETWORKS=`cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'`
+  NUM_GCNETWORKS=`echo $GCNETWORKS | jq '.network | length'`
+}
+
 cleanup() {
     # dont wait for async job - execute in parallel until told otherwise
     cloudmonkey set asyncblock false
     cloudmonkey set output json
     # TODO: N/A
 
-    # Destroy alerts
+    echo "Destroy alerts"
     for id in $(cloudmonkey list alerts listall=true keyword=vm filter=id | jq -r '.alert[] .id'); do
         cloudmonkey delete alerts ids=$id || true
     done
 
-    # Destroy templates, forced, since some VMs might exist.
-    for templateid in $(cloudmonkey list templates templatefilter=self filter=id | jq -r '.template[] .id'); do
-        cloudmonkey delete template id=$templateid forced=true  || true
-    done
+    echo "Destroy templates, forced, since some VMs might exist."
+    GCTEMPLATES=`cmk list templates templatefilter=self`
+    NUM_GCTEMPLATES=`echo $GCTEMPLATES | jq '.template | length'`
+    if [ $NUM_GCTEMPLATES -gt 0 ]; then
+      echo "Test file $file left behind $NUM_GCTEMPLATES templates" >> $CLEAN_UP_LOG
+      for templateid in $(echo $GCTEMPLATES | jq -r '.template[] .id'); do
+          cloudmonkey delete template id=$templateid forced=true  || true
+      done
+    fi
 
-    # Destroy vms, all in parallel
-    for vmid in $(cloudmonkey list virtualmachines listall=true filter=id | jq -r '.virtualmachine[] .id'); do
-        cloudmonkey destroy virtualmachine id=$vmid expunge=true || true
-    done
+  sleepduration=10
+
+    echo "Destroy vms, all in parallel"
+    GCVMS=`cmk list virtualmachines listall=true filter=id`
+    NUM_GCVMS=`echo $GCVMS | jq '.virtualmachine | length'`
+    if [ $NUM_GCVMS -gt 0 ]; then
+      echo "Test file $file left behind $NUM_GCVMS VMs" >> $CLEAN_UP_LOG
+      for vmid in $(echo $GCVMS | jq -r '.virtualmachine[] .id'); do
+          cloudmonkey destroy virtualmachine id=$vmid expunge=true || true
+      done
+      echo "wait ${sleepduration}s to give VM destory some time"
+      sleep $sleepduration
+    fi
 
     # Not neeed to destroy VRs explicitely, will be destroyed with network/VPC - otherwise later deleting network/VPC fails if VR is gone!!!
 
 # Set sleep time (seconds) between checks if child resources deleted; i.e. 5secs
-  sleepduration=5
+  sleepduration=10
 # Set max number of retires after the sleep period - i.e. if child resource is not deleted withing $sleepduration x $maxretries,
 # then move on and hope for the best; i.e. 60secs (total of 300sec waiting time)
-  maxretries=60
-
-    # Destroy networks only when no more VMS (otherwise will fail if network contains a VM)
-        NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
-        retries=0
-        while [ $NoVMs -ne 0 ]
-         do
-          echo "Retrying in $sleepduration sec"
-          sleep $sleepduration
-             if [[ "$NoVMs" == '0' ]]; then
-                echo "No more VMs, about to wipe Networks..."
-                break
-             fi
-             if [[ "$retries" == "$maxretries" ]]; then
-                echo "Waited for some time, giving up, trying wiping networks..."
-                break
-             fi
-           NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
-           (( retries++ ))
-         done
-    for netid in $(cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'); do
+  retries=60
+  
+  echo "deleting netowrks"
+  count_networks
+  if [ $NUM_GCNETWORKS -gt 0 ]; then
+    echo "Test file $file left behind $NUM_GCNETWORKS Networks" >> $CLEAN_UP_LOG    
+    while [ $retries -gt 0 ]     
+    do 
+      for netid in $(cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'); do
         cloudmonkey delete network id=$netid || true
+      done
+    echo "wait ${sleepduration}s to give Networks some time to destroy"
+    sleep $sleepduration
+    count_networks
+    if [ $NUM_GCNETWORKS -gt 0 ]; then
+      retries=$((retries)-1)
+    else
+      retries=0
+    fi
     done
+  fi   
 
-    # Destroy vpcs, only if no networks present (otherwise will fail if VPC has networks)
-         NoNets=$(cloudmonkey list networks filter=id | grep id | wc -l)
-         retries=0
-         while [ $NoNets -ne 0 ]
-         do
-          echo "Retrying in $sleepduration sec"
-          sleep $sleepduration
-             if [[ "$NoNets" == '0' ]]; then
-                echo "No more networks, about to wipe VPCs..."
-                break
-             fi
-             if [[ "$retries" == "$maxretries" ]]; then
-                echo "Waited for some time, giving up, trying wiping VPCs..."
-                break
-             fi
-           NoNets=$(cloudmonkey list networks filter=id | grep id | wc -l)
-           (( retries++ ))
-         done
+  echo "deleting VPCs"
+  GCVPCS=`cloudmonkey list vpcs listall=true filter=id | jq -r '.vpc[] .id'`
+  NUM_GCVPCS=`echo $VPCs | jq '.VPC | length'`
+  if [ $NUM_GCVPC -gt 0 ]; then
+    echo "$file left $NUM_GCVPCS behind"
     for vid in $(cloudmonkey list vpcs listall=true filter=id | jq -r '.vpc[] .id'); do
         cloudmonkey delete vpc id=$vid || true
     done

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -35,32 +35,92 @@ rm -f /usr/lib/python2.7/site-packages/marvin/config/*pyc
 rm -f /usr/lib/python2.7/site-packages/marvin/lib/*pyc
 
 cleanup() {
+    # dont wait for async job - execute in parallel until told otherwise
     cloudmonkey set asyncblock false
-    cloudmonkey set display default
-    # TODO: destroy accounts, domains, templates
-    # Destroy vms
-    for vmid in $(cloudmonkey list virtualmachines listall=true filter=id | grep '^id' | awk '{print $3}'); do
-        cloudmonkey destroy virtualmachine id=$vmid expunge=true || true
-    done
-    # Destroy routers
-    for rid in $(cloudmonkey list routers listall=true filter=id | grep '^id' | awk '{print $3}'); do
-        cloudmonkey destroy router id=$rid || true
-    done
-    # Destroy networks
-    for netid in $(cloudmonkey list networks listall=true filter=id | grep '^id' | awk '{print $3}'); do
-        cloudmonkey delete network id=$netid || true
-    done
-    # Destroy vpcs
-    for vid in $(cloudmonkey list vpcs listall=true filter=id | grep '^id' | awk '{print $3}'); do
-        cloudmonkey delete vpc id=$vid || true
-    done
+    cloudmonkey set output json
+    # TODO: N/A
+
     # Destroy alerts
-    for id in $(cloudmonkey list alerts listall=true keyword=auth-error filter=id | grep '^id' | awk '{print $3}'); do
+    for id in $(cloudmonkey list alerts listall=true keyword=vm filter=id | jq -r '.alert[] .id'); do
         cloudmonkey delete alerts ids=$id || true
     done
-   # Destroy tepla
-    for templateid in $(cloudmonkey list templates templatefilter=self filter=id | grep '^id' | awk '{print $3}'); do
-        cloudmonkey delete template id=$templateid || true
+
+    # Destroy templates, forced, since some VMs might exist.
+    for templateid in $(cloudmonkey list templates templatefilter=self filter=id | jq -r '.template[] .id'); do
+        cloudmonkey delete template id=$templateid forced=true  || true
+    done
+
+    # Destroy vms, all in parallel
+    for vmid in $(cloudmonkey list virtualmachines listall=true filter=id | jq -r '.virtualmachine[] .id'); do
+        cloudmonkey destroy virtualmachine id=$vmid expunge=true || true
+    done
+
+    # Not needed to destroy VRs explicitely, will be destroyed with network/VPC
+
+    # Destroy networks only when no more VMS (otherwise will fail if network contains a VM)
+         NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
+         while [ $NoVMs -ne 0 ]
+         do
+          sleep 5
+          #echo "sleeping 5 sec"
+             if [[ "$NoVMs" == '0' ]]; then
+             break
+             fi
+          NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
+         done
+    for netid in $(cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'); do
+        cloudmonkey delete network id=$netid || true
+    done
+
+    # Destroy vpcs, only if no networks present (otherwise will fail if VPC has networks)
+         NoNets=$(cloudmonkey list networks filter=id | grep id | wc -l)
+         while [ $NoNets -ne 0 ]
+         do
+          sleep 5
+          #echo "sleeping 5 sec"
+             if [[ "$NoNets" == '0' ]]; then
+             break
+             fi
+          NoNets=$(cloudmonkey list networks filter=id | grep id | wc -l)
+         done
+    for vid in $(cloudmonkey list vpcs listall=true filter=id | jq -r '.vpc[] .id'); do
+        cloudmonkey delete vpc id=$vid || true
+    done
+
+    # move to blocking asyn calls (just volume deletion, should be very fast), so later we can delete accounts and domains gracefully
+    cloudmonkey set asyncblock true
+
+    # Destroy data volumes when zero attached (all VMs deleted)
+      NoAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
+         while [ $NoAttachedVolumes -ne 0 ]
+         do
+          sleep 5
+          #echo "sleeping 5 sec"
+             if [[ "$NoAttachedVolumes" == '0' ]]; then
+             break
+             fi
+          NoAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
+         done
+    for volumeid in $(cloudmonkey list volumes listall=true type=data filter=id | jq -r '.volume[] .id'); do
+        cloudmonkey delete volume id=$volumeid || true
+    done
+
+cloudmonkey set asyncblock true
+
+    # Destroy accounts (keep some, delete all others)
+    cloudmonkey list accounts listall=true filter=id name="baremetal-system-account" | jq -r '.account[] .id'  > .skipdeletingaccounts
+    cloudmonkey list accounts listall=true filter=id name="ACSuser" | jq -r '.account[] .id'  >> .skipdeletingaccounts
+    cloudmonkey list accounts listall=true filter=id name="admin" | jq -r '.account[] .id'  >> .skipdeletingaccounts
+    cloudmonkey list accounts listall=true filter=id | jq -r '.account[] .id'  > .deleteaccounts
+    for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
+        cloudmonkey delete account id=$accountid || true
+    done
+
+    # Destroy domains (keep ROOT domain, delete all other), with cleanup (delete children domains accounts)
+    cloudmonkey list domains listall=true filter=id name=ROOT | jq -r '.domain[] .id' > .skipdeletingdomain
+    cloudmonkey list domains listall=true filter=id | jq -r '.domain[] .id' > .deletedomain
+    for domainid in $(comm -13 <(sort -u .skipdeletingdomain) <(sort -u .deletedomain)); do
+        cloudmonkey delete domain id=$domainid cleanup=true || true
     done
 
 }

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -55,18 +55,31 @@ cleanup() {
         cloudmonkey destroy virtualmachine id=$vmid expunge=true || true
     done
 
-    # Not needed to destroy VRs explicitely, will be destroyed with network/VPC
+    # Not neeed to destroy VRs explicitely, will be destroyed with network/VPC - otherwise later deleting network/VPC fails if VR is gone!!!
+
+# Set sleep time (seconds) between checks if child resources deleted; i.e. 5secs
+  sleepduration=5
+# Set max number of retires after the sleep period - i.e. if child resource is not deleted withing $sleepduration x $maxretries,
+# then move on and hope for the best; i.e. 60secs (total of 300sec waiting time)
+  maxretries=60
 
     # Destroy networks only when no more VMS (otherwise will fail if network contains a VM)
-         NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
-         while [ $NoVMs -ne 0 ]
+        NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
+        retries=0
+        while [ $NoVMs -ne 0 ]
          do
-          sleep 5
-          #echo "sleeping 5 sec"
+          echo "Retrying in $sleepduration sec"
+          sleep $sleepduration
              if [[ "$NoVMs" == '0' ]]; then
-             break
+                echo "No more VMs, about to wipe Networks..."
+                break
              fi
-          NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
+             if [[ "$retries" == "$maxretries" ]]; then
+                echo "Waited for some time, giving up, trying wiping networks..."
+                break
+             fi
+           NoVMs=$(cloudmonkey list virtualmachines filter=id  | grep id | wc -l)
+           (( retries++ ))
          done
     for netid in $(cloudmonkey list networks listall=true filter=id | jq -r '.network[] .id'); do
         cloudmonkey delete network id=$netid || true
@@ -74,38 +87,50 @@ cleanup() {
 
     # Destroy vpcs, only if no networks present (otherwise will fail if VPC has networks)
          NoNets=$(cloudmonkey list networks filter=id | grep id | wc -l)
+         retries=0
          while [ $NoNets -ne 0 ]
          do
-          sleep 5
-          #echo "sleeping 5 sec"
+          echo "Retrying in $sleepduration sec"
+          sleep $sleepduration
              if [[ "$NoNets" == '0' ]]; then
-             break
+                echo "No more networks, about to wipe VPCs..."
+                break
              fi
-          NoNets=$(cloudmonkey list networks filter=id | grep id | wc -l)
+             if [[ "$retries" == "$maxretries" ]]; then
+                echo "Waited for some time, giving up, trying wiping VPCs..."
+                break
+             fi
+           NoNets=$(cloudmonkey list networks filter=id | grep id | wc -l)
+           (( retries++ ))
          done
     for vid in $(cloudmonkey list vpcs listall=true filter=id | jq -r '.vpc[] .id'); do
         cloudmonkey delete vpc id=$vid || true
     done
 
-    # move to blocking asyn calls (just volume deletion, should be very fast), so later we can delete accounts and domains gracefully
+    # move to blocking async calls (just volume deletion, should be very fast), so later we can delete accounts and domains
     cloudmonkey set asyncblock true
 
     # Destroy data volumes when zero attached (all VMs deleted)
-      NoAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
-         while [ $NoAttachedVolumes -ne 0 ]
-         do
-          sleep 5
-          #echo "sleeping 5 sec"
-             if [[ "$NoAttachedVolumes" == '0' ]]; then
-             break
+        NumAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
+        retries=0
+        while [ $NumAttachedVolumes -ne 0 ]
+       do
+          echo "Retrying in $sleepduration sec"
+          sleep $sleepduration
+             if [[ "$NumAttachedVolumes" == '0' ]]; then
+                echo "No more VMs, about to wipe all DATA Volumes..."
+                break
              fi
-          NoAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
+             if [[ "$retries" == "$maxretries" ]]; then
+                echo "Waited for some time, giving up, trying wiping VPCs..."
+                break
+             fi
+           NumAttachedVolumes=$(cloudmonkey list volumes type=data  | grep virtualmachineid | wc -l)
+           (( retries++ ))
          done
     for volumeid in $(cloudmonkey list volumes listall=true type=data filter=id | jq -r '.volume[] .id'); do
         cloudmonkey delete volume id=$volumeid || true
     done
-
-cloudmonkey set asyncblock true
 
     # Destroy accounts (keep some, delete all others)
     cloudmonkey list accounts listall=true filter=id name="baremetal-system-account" | jq -r '.account[] .id'  > .skipdeletingaccounts
@@ -116,13 +141,17 @@ cloudmonkey set asyncblock true
         cloudmonkey delete account id=$accountid || true
     done
 
-    # Destroy domains (keep ROOT domain, delete all other), with cleanup (delete children domains accounts)
-    cloudmonkey list domains listall=true filter=id name=ROOT | jq -r '.domain[] .id' > .skipdeletingdomain
-    cloudmonkey list domains listall=true filter=id | jq -r '.domain[] .id' > .deletedomain
-    for domainid in $(comm -13 <(sort -u .skipdeletingdomain) <(sort -u .deletedomain)); do
-        cloudmonkey delete domain id=$domainid cleanup=true || true
+    # Destroy domains (keep ROOT domain, delete all other)
+    cloudmonkey list domains listall=true filter=id name=ROOT | jq -r '.domain[] .id' > .skipdeletingdomains
+    cloudmonkey list domains listall=true filter=id | jq -r '.domain[] .id' > .deletedomains
+    for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
+        cloudmonkey delete domain id=$domainid || true
     done
-
+# cleanup
+rm -f .skipdeletingaccounts
+rm -f .deleteaccounts
+rm -f .skipdeletingdomain
+rm -f .deletedomain
 }
 
 runtest() {

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -83,6 +83,7 @@ cmk list diskofferings listall=true issystem=false name='custom' | jq -r '.disko
 cmk list domains listall=true name="root" | jq -r '.domain[].id' > .skipdeletedomains
 touch $CLEAN_UP_LOG
 
+
 cleanup() {
 
   # dont wait for async job - execute in parallel until told otherwise
@@ -98,18 +99,19 @@ cleanup() {
   echo "Destroy templates, forced, since some VMs might exist."
   NUM_GCTEMPLATES=`cmk list templates templatefilter=self listall=true | jq -r '.template[].id' | wc -l`
   if [[ $NUM_GCTEMPLATES -gt $STUCKTEMPLATES ]]; then
-    echo "Test file $file left behind $(($NUM_GCTEMPLATES-$STUCKTEMPLATES)) templates" >> $CLEAN_UP_LOG
-    for templateid in $(echo $GCTEMPLATES | jq -r '.template[].id'); do
+    echo "$(basename $file) left behind $(($NUM_GCTEMPLATES-$STUCKTEMPLATES)) templates" >> $CLEAN_UP_LOG
+    cloudmonkey set asyncblock true
+    for templateid in $(cmk list templates templatefilter=self listall=true | jq -r '.template[].id'); do
       cmk delete template id=$templateid forced=true  || true
     done
-    sleep $((sleepduration*2))
     STUCKTEMPLATES=`cmk list templates templatefilter=self | jq -r '.template[].id' | wc -l`
   fi
 
   echo "Destroy vms, all in parallel"
-  NUM_GCVMS=`cmk list virtualmachines listall=true $GCVMS | jq -r '.count'`
+  cloudmonkey set asyncblock false
+  NUM_GCVMS=`cmk list virtualmachines listall=true $GCVMS | jq -r '.virtualmachine[].id' | wc -l`
   if [[ $NUM_GCVMS -gt $STUCKVMS ]]; then
-    echo "Test file $file left behind $(($NUM_GCVMS-$STUCKVMS)) VMs" >> $CLEAN_UP_LOG
+    echo "$(basename $file) left behind $(($NUM_GCVMS-$STUCKVMS)) VMs" >> $CLEAN_UP_LOG
     for vmid in $(cmk list virtualmachines listall=true $GCVMS | jq -r '.virtualmachine[].id'); do
       cmk destroy virtualmachine id=$vmid expunge=true || true
     done
@@ -135,7 +137,7 @@ cleanup() {
   echo "deleting networks"
   NUM_GCNETWORKS=`cmk list networks listall=true | jq -r '.network[].id' | wc -l`
   if [[ $NUM_GCNETWORKS -gt $STUCKNETWORKS ]]; then
-    echo "Test file $file left $(($NUM_GCNETWORKS-$STUCKNETWORKS)) Networks behind" >> $CLEAN_UP_LOG    
+    echo "$(basename $file) left behind $(($NUM_GCNETWORKS-$STUCKNETWORKS)) Networks" >> $CLEAN_UP_LOG    
     while [ $tries -gt 0 ]     
     do 
       for netid in $(cmk list networks listall=true | jq -r '.network[].id'); do
@@ -143,7 +145,7 @@ cleanup() {
       done
     echo "wait ${sleepduration}s to give Networks some time to destroy"
     sleep $sleepduration
-    NUM_GCNETWORKS=`cmk networks listall=true | jq -r '.count'`
+    NUM_GCNETWORKS=`cmk networks listall=true | jq -r '.network[].id' | wc -l`
     if [[ $NUM_GCNETWORKS -gt $STUCKVMS ]]; then
       tries=$((retries)-1)
     else
@@ -157,13 +159,13 @@ cleanup() {
   echo "deleting VPCs"
   NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.vpc[].id' | wc -l`
   if [[ $NUM_GCVPC -gt $STUCKVPCS ]]; then
-    echo "Test $file left $(($NUM_GCVPCS-$STUCKVPCS)) VPCs behind" >> $CLEAN_UP_LOG
+    echo "$(basename $file) left behind $(($NUM_GCVPCS-$STUCKVPCS)) VPCs" >> $CLEAN_UP_LOG
     while [ $tries -gt 0 ]; do
       for vid in $(cmk list vpcs listall=true | jq -r '.vpc[].id'); do
         cmk delete vpc id=$vid || true
       done
       sleep $sleepduration
-      NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.count'`
+      NUM_GCVPCS=`cmk list vpcs listall=true |jq -r '.vpc[].id' | wc -l`
       if [ $NUM_GCVPCS -gt $STUCKVPCS ]; then
         tries=$((retries)-1)
       else
@@ -179,7 +181,7 @@ cleanup() {
   # Destroy data volumes when zero attached (all VMs deleted)
   NUM_GCVOLS=$(cmk list volumes type=data | jq -r '.volume[].id' | wc -l)
   if [[ $NUM_GCVOLS -gt $STUCKVOLS ]]; then
-    echo "$file left $(($NUM_GCVOLS-$STUCKVOLS)) volumes behind" >> $CLEAN_UP_LOG
+    echo "$(basename $file) left behind $(($NUM_GCVOLS-$STUCKVOLS)) volumes" >> $CLEAN_UP_LOG
     for volumeid in $(cmk list volumes listall=true type=data | jq -r '.volume[] .id'); do
       cmk delete volume id=$volumeid || true
     done
@@ -192,7 +194,7 @@ cleanup() {
   cmk list accounts listall=true | jq -r '.account[] .id'  > .deleteaccounts
   NUM_LEFT=`cat .deleteaccounts | wc -l`
   if [[ $NUM_LEFT -gt 3 ]]; then
-    echo "$file left $(($NUM_LEFT-3)) accounts behind"
+    echo "$(basename $file) left behind $(($NUM_LEFT-3)) accounts" >> $CLEAN_UP_LOG
     for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
       cmk delete account id=$accountid || true
     done
@@ -202,8 +204,8 @@ cleanup() {
   cmk list domains listall=true | jq -r '.domain[] .id' > .deletedomains
   NUM_LEFT=`cat .deletedomains | wc -l`
   if [[ $NUM_LEFT -gt 1 ]]; then
-    echo "$file left $(($NUM_LEFT-1)) accounts behind"
-    for domainid in $(comm -13 <(sort -u .skipdeletedomains) <(sort -u .deletedomains)); do
+    echo "$(basename $file) left behind $(($NUM_LEFT-3)) domains" >> $CLEAN_UP_LOG
+    for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
       cmk delete domain id=$domainid || true
     done
   fi
@@ -211,7 +213,7 @@ cleanup() {
   cmk list serviceofferings listall=true issystem=false | jq -r '.serviceoffering[].id' > .deleteofferings
   NUM_LEFT=`cat .deleteofferings | wc -l`
   if [[ $NUM_LEFT -gt 2 ]]; then
-    echo "$file left $(($NUM_LEFT-2)) accounts behind"
+    echo "$(basename $file) left behind $(($NUM_LEFT-3)) service offerings" >> $CLEAN_UP_LOG
     for offeringid in $(comm -13 <(sort -u .skipdeleteofferings) <(sort -u .deleteofferings)); do
       cmk delete serviceoffering id=$offeringid || true
     done
@@ -220,7 +222,7 @@ cleanup() {
   cmk list diskofferings listall=true issystem=false | jq -r '.diskoffering[].id' > .deletediskofferings
   NUM_LEFT=`cat .deletediskofferings | wc -l `
   if [[ $NUM_LEFT -gt 4 ]]; then
-    "$file left $(($NUM_LEFT-4)) accounts behind"
+    "$(basename $file) left behind $(($NUM_LEFT-3)) disk offerings" >> $CLEAN_UP_LOG
     for offeringid in $(comm -13 <(sort -u .skipdeletediskofferings) <(sort -u .deletediskofferings)); do
       cmk delete diskoffering id=$offeringid || true
     done

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -80,7 +80,7 @@ cmk list diskofferings listall=true issystem=false name='small' | jq -r '.diskof
 cmk list diskofferings listall=true issystem=false name='medium' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
 cmk list diskofferings listall=true issystem=false name='large' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
 cmk list diskofferings listall=true issystem=false name='custom' | jq -r '.diskoffering[].id' >> .skipdeletediskofferings
-cmk list domains listall=true name="root" | jq -r '.domain[].id' > .skipdeletingdomains
+cmk list domains listall=true name="root" | jq -r '.domain[].id' > .skipdeletedomains
 touch $CLEAN_UP_LOG
 
 cleanup() {
@@ -96,14 +96,14 @@ cleanup() {
   done
 
   echo "Destroy templates, forced, since some VMs might exist."
-  NUM_GCTEMPLATES=`cmk list templates templatefilter=self listall=true | jq -r '.template[] | length'`
+  NUM_GCTEMPLATES=`cmk list templates templatefilter=self listall=true | jq -r '.template[].id' | wc -l`
   if [[ $NUM_GCTEMPLATES -gt $STUCKTEMPLATES ]]; then
     echo "Test file $file left behind $(($NUM_GCTEMPLATES-$STUCKTEMPLATES)) templates" >> $CLEAN_UP_LOG
     for templateid in $(echo $GCTEMPLATES | jq -r '.template[].id'); do
       cmk delete template id=$templateid forced=true  || true
     done
-    sleep $((sleepduration)*2)
-    STUCKTEMPLATES=`cmk list templates templatefilter=self | jq -r '.template[] | length'`
+    sleep $((sleepduration*2))
+    STUCKTEMPLATES=`cmk list templates templatefilter=self | jq -r '.template[].id' | wc -l`
   fi
 
   echo "Destroy vms, all in parallel"
@@ -120,7 +120,7 @@ cleanup() {
   tries=$retries
   while [ $tries -gt 0 ]     
   do 
-    NUM_GCVMS=`cmk list virtualmachines listall=true| jq -r '.virtualmachine[] | length'`
+    NUM_GCVMS=`cmk list virtualmachines listall=true| jq -r '.virtualmachine[].id' | wc -l`
     if [[ $NUM_GCVMS -gt $STUCKVMS ]]; then
       echo "Still $NUM_GCVMS left. waiting.."
       sleep $sleepduration
@@ -133,7 +133,7 @@ cleanup() {
 
   tries=$retries
   echo "deleting networks"
-  NUM_GCNETWORKS=`cmk list networks listall=true | jq -r '.network[] | length'`
+  NUM_GCNETWORKS=`cmk list networks listall=true | jq -r '.network[].id' | wc -l`
   if [[ $NUM_GCNETWORKS -gt $STUCKNETWORKS ]]; then
     echo "Test file $file left $(($NUM_GCNETWORKS-$STUCKNETWORKS)) Networks behind" >> $CLEAN_UP_LOG    
     while [ $tries -gt 0 ]     
@@ -155,7 +155,7 @@ cleanup() {
  
   tries=$retries
   echo "deleting VPCs"
-  NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.vpc[] | length'`
+  NUM_GCVPCS=`cmk list vpcs listall=true | jq -r '.vpc[].id' | wc -l`
   if [[ $NUM_GCVPC -gt $STUCKVPCS ]]; then
     echo "Test $file left $(($NUM_GCVPCS-$STUCKVPCS)) VPCs behind" >> $CLEAN_UP_LOG
     while [ $tries -gt 0 ]; do
@@ -177,14 +177,14 @@ cleanup() {
   cloudmonkey set asyncblock true
 
   # Destroy data volumes when zero attached (all VMs deleted)
-  NUM_GCVOLS=$(cmk list volumes type=data | jq -r '.volume[] | length')
+  NUM_GCVOLS=$(cmk list volumes type=data | jq -r '.volume[].id' | wc -l)
   if [[ $NUM_GCVOLS -gt $STUCKVOLS ]]; then
     echo "$file left $(($NUM_GCVOLS-$STUCKVOLS)) volumes behind" >> $CLEAN_UP_LOG
     for volumeid in $(cmk list volumes listall=true type=data | jq -r '.volume[] .id'); do
       cmk delete volume id=$volumeid || true
     done
     sleep $sleepduration
-  NUM_GCVOLS=`cmk list volumes listall=true type=data | jq -r '.volume[] | length'`
+  NUM_GCVOLS=`cmk list volumes listall=true type=data | jq -r '.volume[].id' | wc -l`
   STUCKVOLS=$NUM_GCVOLS
   fi
 
@@ -192,7 +192,7 @@ cleanup() {
   cmk list accounts listall=true | jq -r '.account[] .id'  > .deleteaccounts
   NUM_LEFT=`cat .deleteaccounts | wc -l`
   if [[ $NUM_LEFT -gt 3 ]]; then
-    echo "$file left $NUM_LEFT accounts behind"
+    echo "$file left $(($NUM_LEFT-3)) accounts behind"
     for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
       cmk delete account id=$accountid || true
     done
@@ -202,7 +202,8 @@ cleanup() {
   cmk list domains listall=true | jq -r '.domain[] .id' > .deletedomains
   NUM_LEFT=`cat .deletedomains | wc -l`
   if [[ $NUM_LEFT -gt 1 ]]; then
-    for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
+    echo "$file left $(($NUM_LEFT-1)) accounts behind"
+    for domainid in $(comm -13 <(sort -u .skipdeletedomains) <(sort -u .deletedomains)); do
       cmk delete domain id=$domainid || true
     done
   fi
@@ -210,6 +211,7 @@ cleanup() {
   cmk list serviceofferings listall=true issystem=false | jq -r '.serviceoffering[].id' > .deleteofferings
   NUM_LEFT=`cat .deleteofferings | wc -l`
   if [[ $NUM_LEFT -gt 2 ]]; then
+    echo "$file left $(($NUM_LEFT-2)) accounts behind"
     for offeringid in $(comm -13 <(sort -u .skipdeleteofferings) <(sort -u .deleteofferings)); do
       cmk delete serviceoffering id=$offeringid || true
     done
@@ -218,15 +220,16 @@ cleanup() {
   cmk list diskofferings listall=true issystem=false | jq -r '.diskoffering[].id' > .deletediskofferings
   NUM_LEFT=`cat .deletediskofferings | wc -l `
   if [[ $NUM_LEFT -gt 4 ]]; then
+    "$file left $(($NUM_LEFT-4)) accounts behind"
     for offeringid in $(comm -13 <(sort -u .skipdeletediskofferings) <(sort -u .deletediskofferings)); do
       cmk delete diskoffering id=$offeringid || true
     done
   fi
 
-# cleanup 
+# cleanup
 
 rm -f .deleteaccounts
-rm -f .deletedomain
+rm -f .deletedomains
 rm -f .deleteofferings
 rm -f .deletediskofferings
 }
@@ -308,7 +311,7 @@ for file in $FILES; do
 done
 
 rm -f .skipdeletingaccounts
-rm -f .skipdeletingdomain
+rm -f .skipdeletedomain
 rm -f .skipdeleteofferings
 rm -f .skipdeletediskofferings
 

--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -191,7 +191,7 @@ cleanup() {
   # Destroy accounts (keep some, delete all others)
   cmk list accounts listall=true | jq -r '.account[] .id'  > .deleteaccounts
   NUM_LEFT=`cat .deleteaccounts | wc -l`
-  if [[ $NUM_LEFT -gt 0 ]]; then
+  if [[ $NUM_LEFT -gt 3 ]]; then
     echo "$file left $NUM_LEFT accounts behind"
     for accountid in $(comm -13 <(sort -u .skipdeletingaccounts) <(sort -u .deleteaccounts)); do
       cmk delete account id=$accountid || true
@@ -201,7 +201,7 @@ cleanup() {
   # Destroy domains (keep ROOT domain, delete all other)
   cmk list domains listall=true | jq -r '.domain[] .id' > .deletedomains
   NUM_LEFT=`cat .deletedomains | wc -l`
-  if [[ $NUM_LEFT -gt 0 ]]; then
+  if [[ $NUM_LEFT -gt 1 ]]; then
     for domainid in $(comm -13 <(sort -u .skipdeletingdomains) <(sort -u .deletedomains)); do
       cmk delete domain id=$domainid || true
     done
@@ -209,17 +209,17 @@ cleanup() {
 
   cmk list serviceofferings listall=true issystem=false | jq -r '.serviceoffering[].id' > .deleteofferings
   NUM_LEFT=`cat .deleteofferings | wc -l`
-  if [[ $NUM_LEFT -gt 0 ]]; then
+  if [[ $NUM_LEFT -gt 2 ]]; then
     for offeringid in $(comm -13 <(sort -u .skipdeleteofferings) <(sort -u .deleteofferings)); do
-      cmk delete serviceofferings id=$offeringid || true
+      cmk delete serviceoffering id=$offeringid || true
     done
   fi
 
   cmk list diskofferings listall=true issystem=false | jq -r '.diskoffering[].id' > .deletediskofferings
   NUM_LEFT=`cat .deletediskofferings | wc -l `
-  if [[ $NUM_LEFT -gt 0 ]]; then
+  if [[ $NUM_LEFT -gt 4 ]]; then
     for offeringid in $(comm -13 <(sort -u .skipdeletediskofferings) <(sort -u .deletediskofferings)); do
-      cmk delete diskofferings id=$offeringid || true
+      cmk delete diskoffering id=$offeringid || true
     done
   fi
 


### PR DESCRIPTION
Step by step deletion of resources, should NOT fail unless some VM is stuck in "Expunging state" - or some other DB corruption which blocks normal deletion of resources.
Added comments for readability - later can be removed.
Tested across 2 different installations.

cloudmonkey output changed to JSON (but we could also keep "text" for compatibility with cloudmonkey 5.3...)
Steps/logic:
- cloudmonkey set to works in asyncblock=false
- alerts are destroyed
- templates are forcefully removed, all in parallel
- VMs are removed all in parallel, 
- only then networks are removed, all in parallel
- only then VPCs are removed. all in parallel
- -cloudmonkey now changed to async  blocking mode (one command/API call by one)
- all accounts are deleted (also any left-over resources...), 
- all domains are deleted with cleanup=true (subdomains are deleted as well)
- if child resoruces are not deleted after $sleepduration x $maxretries (300sec), continue and hope for the best