### PR TITLE
fix-ubuntu-usage-service-installation

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -63,6 +63,16 @@
   with_items:
     - cloudstack-management
 
+# no need to remove, unless proven otherise - same as for CentOS
+#- name: remove CloudStack repository into sources list.
+#  apt_repository:
+#    repo: 'deb {{ baseurl_kvm }} /'
+#    state: absent
+
+#- name: Run the equivalent of "apt-get update" as a separate step
+#  apt:
+#    update_cache: yes
+
 - name: Ensure extra packages are installed
   apt:
     pkg: "{{ item }}"

--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -63,12 +63,10 @@
   with_items:
     - cloudstack-management
 
-# no need to remove, unless proven otherise - same as for CentOS
+# no need to remove - same as for CentOS
 #- name: remove CloudStack repository into sources list.
-#  apt_repository:
-#    repo: 'deb {{ baseurl_kvm }} /'
-#    state: absent
-
+#  apt_repository: repo='deb "{{ baseurl_cloudstack }}" /' state=absent
+#
 #- name: Run the equivalent of "apt-get update" as a separate step
 #  apt:
 #    update_cache: yes

--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -55,21 +55,13 @@
   apt:
     update_cache: yes
 
-- name: Ensure CloudStack packages are installed
+- name: Ensure CloudStack management-server only is installed (we install usage server later)
   apt:
     pkg: "{{ item }}"
     state: present
     allow_unauthenticated: yes
   with_items:
     - cloudstack-management
-    - cloudstack-usage
-
-- name: remove CloudStack repository into sources list.
-  apt_repository: repo='deb "{{ baseurl_cloudstack }}" /' state=absent
-
-- name: Run the equivalent of "apt-get update" as a separate step
-  apt:
-    update_cache: yes
 
 - name: Ensure extra packages are installed
   apt:
@@ -84,6 +76,14 @@
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
 
 - include: ./setupdb.yml
+
+- name: Ensure CloudStack packages are installed (now that mgmt server "db.properties" and "key" files are present)
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    allow_unauthenticated: yes
+  with_items:
+    - cloudstack-usage
 
 - name: Ensure CloudStack Usage Service is started
   service: name=cloudstack-usage state=started

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -200,14 +200,15 @@
   with_items:
     - cloudstack-agent
 
-- name: remove CloudStack repository into sources list.
-  apt_repository:
-    repo: 'deb {{ baseurl_kvm }} /'
-    state: absent
+# no need to remove, unless proven otherise - same as for CentOS
+#- name: remove CloudStack repository into sources list.
+#  apt_repository:
+#    repo: 'deb {{ baseurl_kvm }} /'
+#    state: absent
 
-- name: Run the equivalent of "apt-get update" as a separate step
-  apt:
-    update_cache: yes
+#- name: Run the equivalent of "apt-get update" as a separate step
+#  apt:
+#    update_cache: yes
 
 - name: Configure agent.properties for OVS
   lineinfile:

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -200,7 +200,7 @@
   with_items:
     - cloudstack-agent
 
-# no need to remove, unless proven otherise - same as for CentOS
+# no need to remove - same as for CentOS
 #- name: remove CloudStack repository into sources list.
 #  apt_repository:
 #    repo: 'deb {{ baseurl_kvm }} /'


### PR DESCRIPTION
Install usage server later, after proper "db.properties" and "key" files are generated for the mgmt server.
Usage server will, during installation, create proper links to db.properties and key files, and be able to start.
Also, don't remove the cloudstack.list file - saves a bit of time during manual upgrades