### PR TITLE
[DO NOT MERGE - changes not in community] Use custom (local) URL for templates ONLY when ACS version < 4.14

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
@@ -34,7 +34,7 @@
   acs_mysql_update: DBHOST="{{ mysql_master_ip }}" DBUSER="cloud" DBPASS={{ mysql_cloud_password }} MYSQL_STATEMENT="UPDATE cloud.vm_template SET url='{{ item.url }}' WHERE id='{{ item.id }}';"
   with_items:
   - "{{ local_builtin_templates }}"
-  when: use_local_templates and ("primary_cs_manager" in group_names)
+  when: use_local_templates and ("primary_cs_manager" in group_names) and (env_numversion | version_compare('4.14','<'))
   tags:
     - "global_settings"
 


### PR DESCRIPTION
Since we need to split Trillian to spin envs with OLD/centos55 templates for all ACS envs < 4.14, but use NEW/CentOS8 templates for ACS envs >= 4.14 -  I've added the condition to (continue to) use custom/local URLs for builtin templates, otherwise if ACS >=4.14 don't replace URLs and continue to use stock ones from the DB i.e. CentOS8 will be used in ACS 4.14+ (from upstream repos, per the original DB content/URLs)