### PR TITLE
Don't use local EPEL repo

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/centos.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos.yml
@@ -20,7 +20,6 @@
 - name: set yum repo to local
   template: src="{{ inventory_dir }}/templates/{{ item }}.j2" dest="/etc/yum.repos.d/{{item}}"
   with_items:
-    - "epel.repo"
     - "CentOS-Base.repo"
 
 - name: Ensure CA Certs are latest


### PR DESCRIPTION
keep using default/upstream Epel - we install only a few small packages:

[root@pr3765-t618-vmware-65u2-mgmt1 ~]# yum list installed | grep @epel
haveged.x86_64                       1.9.1-1.el7                     @epel
jq.x86_64                            1.5-1.el7                       @epel
mysql-connector-python.noarch        1.1.6-1.el7                     @epel
oniguruma.x86_64                     5.9.5-3.el7                     @epel
sshpass.x86_64                       1.06-1.el7                      @epel