### PR TITLE
Restore original Epel repo URL

### DIFF
--- a/Ansible/templates/epel.repo.j2
+++ b/Ansible/templates/epel.repo.j2
@@ -1,6 +1,7 @@
 [epel]
-name=Extra Packages for Enterprise Linux 6 - $basearch
-baseurl={{ repohost }}/epel/$releasever/$basearch
+name=Extra Packages for Enterprise Linux 6/7 - $basearch
+#dont use local repo, since there are very frequent sync issues causing broken deployments
+baseurl=http://download.fedoraproject.org/pub/epel/$releasever/$basearch
 #mirrorlist=http://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch
 failovermethod=priority
 enabled=1


### PR DESCRIPTION
...due to very frequent repo sync issues and thus many failed deployments