### PR TITLE
Make UBUNTU actually restart mgmt post setting change and copy id_rsa

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
@@ -73,7 +73,7 @@
 
 - name: restart mgmt service (inc fix for broken stop) for Ubuntu
   shell: "service cloudstack-management stop && sleep 10 && service cloudstack-management stop && sleep 10 && service cloudstack-management start"
-  when: (path_is_cloudstack.stat.exists == True) and (ansible_distribution == "Ubuntu")
+  when: ansible_distribution == "Ubuntu"
   ignore_errors: true
 
 - name: restart mgmt service (inc fix for broken stop)

--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -109,5 +109,6 @@
   
 - name: copy CloudStack id_rsa where Marvin expects to find it
   shell: "mkdir -p /var/cloudstack/management; rsync -av /var/lib/cloudstack/management/ /var/cloudstack/management/"
-  when: ansible_distribution == "Ubuntu"
+  when: (ansible_distribution == "Ubuntu") and (num_marv_hosts > 0)
+
 

--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -79,6 +79,7 @@
     - mysql-client
     - haveged
     - qemu-utils
+    - rsync
 
 - name: Ensure vhd-util is present
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
@@ -105,3 +106,8 @@
 - name: Open 8096 when Marvin is required (Ubuntu)
   shell: "iptables -A INPUT -p tcp --dport ssh -j ACCEPT && iptables-save"
   when: num_marv_hosts > 0
+  
+- name: copy CloudStack id_rsa where Marvin expects to find it
+  shell: "mkdir -p /var/cloudstack/management; rsync -av /var/lib/cloudstack/management/ /var/cloudstack/management/"
+  when: ansible_distribution == "Ubuntu"
+


### PR DESCRIPTION
@PaulAngus please see if I'm missing something - either this "path_is_cloudstack" is broken - or something similar - restarting of mgmt service after global setting changes  (I'm interested particularly in the 8096 port) on Ubuntu is skipped.

Also, copy id_rsa from /var/lib/cloudstack... (Ubuntu location) to /var/cloudstack/.... (CentOS location, where Marvin expects to find it), otherwise many tests will fail.