### PR TITLE
Copy id_rsa to correct path for Marvin

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -79,6 +79,7 @@
     - mysql-client
     - haveged
     - qemu-utils
+    - rsync
 
 - name: Ensure vhd-util is present
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
@@ -105,3 +106,8 @@
 - name: Open 8096 when Marvin is required (Ubuntu)
   shell: "iptables -A INPUT -p tcp --dport ssh -j ACCEPT && iptables-save"
   when: num_marv_hosts > 0
+  
+- name: copy CloudStack id_rsa where Marvin expects to find it
+  shell: "mkdir -p /var/cloudstack/management; rsync -av /var/lib/cloudstack/management/ /var/cloudstack/management/"
+  when: ansible_distribution == "Ubuntu"
+


### PR DESCRIPTION
Marvin expects to find id_rsa on /var/cloudstack/... (CentOS location) and not /var/**lib**/cloudstack/....(Ubuntu location)
Copy it over so that we can run automated Marvin tests, otherwise many will fail