### PR TITLE
kvm-centos: conditional cgroups fix for kvm-agent

### DIFF
--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -134,13 +134,6 @@
     - kvm
     - kvm-agent
 
-- name: Bugfix libvirt cpu issue on ACS 4.5 (CLOUDSTACK-8443)
-  shell: sed -i -e '/cgroup\_controllers/d' /usr/lib64/python2.7/site-packages/cloudutils/serviceConfig.py
-  when: ansible_distribution_major_version == "7"
-  tags:
-    - kvm
-    - kvm-agent
-
 - name: Add iptables rules
   shell: "iptables -I INPUT -p tcp -m tcp --dport {{ item }} -j ACCEPT"
   with_items:

--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -134,6 +134,13 @@
     - kvm
     - kvm-agent
 
+- name: Bugfix libvirt cpu issue on ACS 4.5 (CLOUDSTACK-8443)
+  shell: sed -i -e '/cgroup\_controllers/d' /usr/lib64/python2.7/site-packages/cloudutils/serviceConfig.py
+  when: (ansible_distribution_major_version == "7") and (env_numversion | version_compare('4.9','<='))
+  tags:
+    - kvm
+    - kvm-agent
+
 - name: Add iptables rules
   shell: "iptables -I INPUT -p tcp -m tcp --dport {{ item }} -j ACCEPT"
   with_items:


### PR DESCRIPTION
Remove task for deleting `cgroup_controllers` in `serviceConfig.py`
Verified ACS 4.9 with https://github.com/apache/cloudstack/blob/4.9/python/lib/cloudutils/serviceConfig.py, there is no occurrence of `cgroup_controllers`
With python3 migration, the path for the file will be `/usr/lib/python3.6/site-packages/cloudutils/serviceConfig.py` on CentOS8