### PR TITLE
Fix marvin mysql connector python

### DIFF
--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -78,6 +78,12 @@
     - marvin
     - marvin_install
 
+- name: Install mysql-connector-python
+  yum: name=mysql-connector-python state=latest
+  tags:
+    - marvin
+    - marvin_install
+
 - name: remove yum openSSL package
   yum:
     name: pyOpenSSL
@@ -118,14 +124,6 @@
 
 - name: WORKAROUND **Install pycparser v2.13**
   pip: name=pycparser version=2.13
-
-- name: Install mysql-connector-python
-  pip: name={{ item }} extra_args='--upgrade'
-  with_items:
-  - mysql-connector-python
-  tags:
-    - marvin
-    - marvin_install
 
 - name: ensure atd is running to schedule jobs
   service: name=atd state=started enabled=yes

--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -78,12 +78,6 @@
     - marvin
     - marvin_install
 
-- name: Install mysql-connector-python
-  yum: name=mysql-connector-python state=installed
-  tags:
-    - marvin
-    - marvin_install
-
 - name: remove yum openSSL package
   yum:
     name: pyOpenSSL
@@ -124,6 +118,12 @@
 
 - name: WORKAROUND **Install pycparser v2.13**
   pip: name=pycparser version=2.13
+
+- name: Install mysql-connector-python
+  pip: mysql-connector-python
+  tags:
+    - marvin
+    - marvin_install
 
 - name: ensure atd is running to schedule jobs
   service: name=atd state=started enabled=yes

--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -120,7 +120,9 @@
   pip: name=pycparser version=2.13
 
 - name: Install mysql-connector-python
-  pip: mysql-connector-python
+  pip: name={{ item }} extra_args='--upgrade'
+  with_items:
+  - mysql-connector-python
   tags:
     - marvin
     - marvin_install


### PR DESCRIPTION
Allow using latest version of `mysql-connector-python`.
Even though `cloudstack-marvin` rpm has instruction to install latest mysql-connector-python it fails with the following error,

`17:36:40         "Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\nResolving Dependencies\n--> Running transaction check\n---> Package cloudstack-marvin.x86_64 0:4.15.0.0-shapeblue1837.el7 will be installed\n--> Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package             Arch     Version                        Repository    Size\n================================================================================\nInstalling:\n cloudstack-marvin   x86_64   4.15.0.0-shapeblue1837.el7     cloudstack   488 k\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal download size: 488 k\nInstalled size: 765 k\nDownloading packages:\nRunning transaction check\nRunning transaction test\nTransaction test succeeded\nRunning transaction\n  Installing : cloudstack-marvin-4.15.0.0-shapeblue1837.el7.x86_64          1/1 \nDEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support\nCollecting http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-8.0.20.zip#md5=88588b3f96cd4b48a60edc49f423b8db\n  Downloading http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-8.0.20.zip (12.2 MB)\nCollecting protobuf>=3.0.0\n  Downloading protobuf-3.12.2-cp27-cp27mu-manylinux1_x86_64.whl (1.3 MB)\nRequirement already satisfied, skipping upgrade: setuptools in /usr/lib/python2.7/site-packages (from protobuf>=3.0.0->mysql-connector-python==8.0.20) (26.1.1)\nRequirement already satisfied, skipping upgrade: six>=1.9 in /usr/lib/python2.7/site-packages (from protobuf>=3.0.0->mysql-connector-python==8.0.20) (1.15.0)\nBuilding wheels for collected packages: mysql-connector-python\n  Building wheel for mysql-connector-python (setup.py): started\n  Building wheel for mysql-connector-python (setup.py): finished with status 'done'\n  Created wheel for mysql-connector-python: filename=mysql_connector_python-8.0.20-cp27-cp27mu-linux_x86_64.whl size=364580 sha256=9d522813bd0012b6f19239a54b7446d64ef465c6443f3fc93e99f50f842e7eec\n  Stored in directory: /root/.cache/pip/wheels/f3/b2/34/151882991156c9522d34ee4fa71c843d3b91bcd4e1fca3da95\nSuccessfully built mysql-connector-python\nInstalling collected packages: protobuf, mysql-connector-python\n  Attempting uninstall: mysql-connector-python\n    Found existing installation: mysql-connector-python 2.1.3\nERROR: Cannot uninstall 'mysql-connector-python'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.`
https://jenkins.shapeblue.com/job/acs-pr-trillian/1944/consoleFull

Without the latest install marvin sql connect fails with the following exception,
`mysql.connector.errors.NotSupportedError: Authentication plugin 'caching_sha2_password' is not supported`