### PR TITLE
handle cloudstack-common/usage via env_cs_minor_version

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/centos-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos-acs.yml
@@ -38,7 +38,7 @@
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
 
 - name: Ensure CloudStack Usage Service is installed
-  yum: name=cloudstack-usage state=present
+  yum: name="{{ cloudstack_management_package }}*" state=present
 
 - name: rename CloudStack title in browser (pre 4.11 location)
   shell: sed -i "/document.title =/ c\        document.title = \"{{ env_name_clean }}\";" /usr/share/cloudstack-management/webapps/client/scripts/cloudStack.js || true

--- a/Ansible/roles/cloudstack-manager/tasks/centos-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos-acs.yml
@@ -38,7 +38,7 @@
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
 
 - name: Ensure CloudStack Usage Service is installed
-  yum: name="{{ cloudstack_management_package }}*" state=present
+  yum: name="{{ cloudstack_usage_package }}*" state=present
 
 - name: rename CloudStack title in browser (pre 4.11 location)
   shell: sed -i "/document.title =/ c\        document.title = \"{{ env_name_clean }}\";" /usr/share/cloudstack-management/webapps/client/scripts/cloudStack.js || true

--- a/Ansible/roles/cloudstack-manager/tasks/centos-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos-acs.yml
@@ -20,7 +20,9 @@
 
 - name: Ensure CloudStack packages are installed
   yum:
-    name: "{{ cloudstack_management_package }}*"
+    name: 
+      - "{{ cloudstack_management_package }}*"
+      - "{{ cloudstack_common_package }}*"
     state: present
     enablerepo: base
 

--- a/Ansible/roles/cloudstack-manager/tasks/centos8-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos8-acs.yml
@@ -39,7 +39,7 @@
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
 
 - name: Ensure CloudStack Usage Service is installed
-  dnf: name=cloudstack-usage state=present
+  dnf: name="{{ cloudstack_usage_package }}*" state=present
 
 - include: ./setupdb.yml
 

--- a/Ansible/roles/cloudstack-manager/tasks/centos8-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos8-acs.yml
@@ -24,7 +24,9 @@
 
 - name: Ensure CloudStack packages are installed
   dnf:
-    name: "{{ cloudstack_management_package }}*"
+    name:
+      - "{{ cloudstack_management_package }}*"
+      - "{{ cloudstack_common_package }}*"
     state: present
     enablerepo: base
 

--- a/Ansible/roles/kvm/tasks/centos-acs.yml
+++ b/Ansible/roles/kvm/tasks/centos-acs.yml
@@ -27,8 +27,8 @@
 - name: Ensure CloudStack packages are installed
   yum:
     name:
-      - "{{ cloudstack_agent_package}}*"
-      - "{{ cloudstack_common_package}}*"
+      - "{{ cloudstack_agent_package }}*"
+      - "{{ cloudstack_common_package }}*"
     state: present
     enablerepo: base
   when: ansible_distribution_major_version|int < 8
@@ -39,8 +39,8 @@
 - name: Ensure CloudStack packages are installed
   dnf:
     name:
-      - "{{ cloudstack_agent_package}}*"
-      - "{{ cloudstack_common_package}}*"
+      - "{{ cloudstack_agent_package }}*"
+      - "{{ cloudstack_common_package }}*"
     state: present
   when: ansible_distribution_major_version|int == 8
   tags:

--- a/Ansible/roles/kvm/tasks/centos-acs.yml
+++ b/Ansible/roles/kvm/tasks/centos-acs.yml
@@ -26,7 +26,9 @@
 
 - name: Ensure CloudStack packages are installed
   yum:
-    name: "{{ cloudstack_agent_package}}*"
+    name:
+      - "{{ cloudstack_agent_package}}*"
+      - "{{ cloudstack_common_package}}*"
     state: present
     enablerepo: base
   when: ansible_distribution_major_version|int < 8
@@ -36,7 +38,9 @@
 
 - name: Ensure CloudStack packages are installed
   dnf:
-    name: "{{ cloudstack_agent_package}}*"
+    name:
+      - "{{ cloudstack_agent_package}}*"
+      - "{{ cloudstack_common_package}}*"
     state: present
   when: ansible_distribution_major_version|int == 8
   tags:

--- a/Ansible/templates/nestedgroupvars.j2
+++ b/Ansible/templates/nestedgroupvars.j2
@@ -275,10 +275,8 @@ baseurl_kvm_suffix: "{{ baseurl_kvm_suffix }}"
 baseurl_kvm: "{{ baseurlkvm | default( baseurl ) }}"
 {% if env_dotted_version is not defined or env_cs_subminor_version == env_cs_minor_version %}
 cloudstack_agent_package: "cloudstack-agent"
-cloudstack_common_package: "cloudstack-common"
 {% else %}
 cloudstack_agent_package: "cloudstack-agent-{{ env_cs_numeric_version }}"
-cloudstack_common_package: "cloudstack-common-{{ env_cs_numeric_version }}"
 {% endif %}
 {% endif %}
 

--- a/Ansible/templates/nestedgroupvars.j2
+++ b/Ansible/templates/nestedgroupvars.j2
@@ -191,8 +191,10 @@ use_custom_browser_title: {{ use_custom_browser_title | default( def_use_custom_
 
 {% if env_dotted_version is not defined or env_cs_subminor_version == env_cs_minor_version %}
 cloudstack_management_package: "cloudstack-management"
+cloudstack_common_package: "cloudstack-common"
 {% else %}
 cloudstack_management_package: "cloudstack-management-{{ env_cs_numeric_version }}"
+cloudstack_common_package: "cloudstack-common-{{ env_cs_numeric_version }}"
 {% endif %}
 
 {% if env_cs_distribution != "ccp" %}
@@ -271,8 +273,10 @@ baseurl_kvm_suffix: "{{ baseurl_kvm_suffix }}"
 baseurl_kvm: "{{ baseurlkvm | default( baseurl ) }}"
 {% if env_dotted_version is not defined or env_cs_subminor_version == env_cs_minor_version %}
 cloudstack_agent_package: "cloudstack-agent"
+cloudstack_common_package: "cloudstack-common"
 {% else %}
 cloudstack_agent_package: "cloudstack-agent-{{ env_cs_numeric_version }}"
+cloudstack_common_package: "cloudstack-common-{{ env_cs_numeric_version }}"
 {% endif %}
 {% endif %}
 

--- a/Ansible/templates/nestedgroupvars.j2
+++ b/Ansible/templates/nestedgroupvars.j2
@@ -192,9 +192,11 @@ use_custom_browser_title: {{ use_custom_browser_title | default( def_use_custom_
 {% if env_dotted_version is not defined or env_cs_subminor_version == env_cs_minor_version %}
 cloudstack_management_package: "cloudstack-management"
 cloudstack_common_package: "cloudstack-common"
+cloudstack_usage_package: "cloudstack-usage"
 {% else %}
 cloudstack_management_package: "cloudstack-management-{{ env_cs_numeric_version }}"
 cloudstack_common_package: "cloudstack-common-{{ env_cs_numeric_version }}"
+cloudstack_usage_package: "cloudstack-usage-{{ env_cs_numeric_version }}"
 {% endif %}
 
 {% if env_cs_distribution != "ccp" %}


### PR DESCRIPTION
... to be able to use env_cs_minor_version, because when instaling env_cs_minor_version shapeblue1 (from the folde where shapeblue3 are present), it will pull the latest cloudstack-common_shapeblue3, which in turn will "upgrade" the management also to shapeblue3... so the env_cs_minor_version doesn't work