### PR TITLE
Adding python kubernetes dependency for smoke tests

### DIFF
--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -92,6 +92,7 @@
   - six
   - pyOpenSSL
   - wheel==0.34.2
+  - kubernetes
   tags:
     - marvin
     - marvin_install


### PR DESCRIPTION
Fix for https://github.com/apache/cloudstack/pull/4329