### PR TITLE
Elrepo el8

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
@@ -89,9 +89,9 @@
 - name: restart mgmt service (inc fix for broken stop)
   shell: "service cloud-management stop && sleep 5 && service cloud-management stop && sleep 10 && service cloud-management start"
   when: (path_is_cloudstack.stat.exists == False) and (ansible_distribution_major_version == "6")
-  ignore_errors: true
+# ignore_errors: true
 
-- name: restart mgmt service (centos7 - systemctl)
-  service: name=cloudstack-management state=restarted
+- name: restart mgmt service (shell, due to module failing atm on Ubuntu20)
+  shell: "systemctl restart cloudstack-management"
   when: ansible_distribution_major_version != "6"
-  ignore_errors: true
+# ignore_errors: true

--- a/Ansible/roles/kvm/tasks/centos8.yml
+++ b/Ansible/roles/kvm/tasks/centos8.yml
@@ -210,6 +210,6 @@
   shell: "echo {{ kvm_password }} | passwd {{ kvm_username }} --stdin"
 
 - include: ./centos_elrepokernel.yml
-  when: kvm_install_elrepo_kernel
+# when: kvm_install_elrepo_kernel
   tags:
     - kvm

--- a/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
+++ b/Ansible/roles/kvm/tasks/centos_elrepokernel.yml
@@ -24,8 +24,13 @@
 - name: Setup ELrepo-kernel yum repository
   template: src=elrepo.repo.j2 dest=/etc/yum.repos.d/elrepo.repo
 
-- name: Install ELrepo kernel
+- name: Install ELrepo kernel 6/7
   shell: "yum --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
+  when: ( ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' ) and ( ansible_distribution_major_version|int < 8 )
+
+- name: Install ELrepo kernel 8
+  shell: "dnf --enablerepo=elrepo-kernel install {{ kvm_elrepo_kernel_version }} -y"
+  when: ( ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' ) and ( ansible_distribution_major_version|int == 8 )
 
 - name: Set ELrepo kernel as the default (CentOS 6)
   shell: sed -i '/default=1/c\default=0' /boot/grub/grub.conf
@@ -34,6 +39,8 @@
 - name: Set ELrepo kernel as the default one (CentOS 7)
   shell: grub2-set-default 0
   when: (ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux') and (ansible_distribution_major_version == "7")
+
+# centos8 - kernel is set as default, by default
 
 - name: Reboot KVM host to load ELrepo kernel
   shell: /sbin/reboot

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -365,3 +365,9 @@
   async: 0
   poll: 0
   ignore_errors: true
+
+# Kernel 5.8+, because the stock kernel + EPYC CPU = can't start any VM on the host
+- include: ./ubuntu_custom_kernel.yml
+  when: ansible_distribution_version|version_compare('20.04','>=')
+  tags:
+    - kvm

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -366,6 +366,10 @@
   poll: 0
   ignore_errors: true
 
+- name: wait for ssh
+  local_action: wait_for port=22 host="{{ ansible_ssh_host }}" timeout={{ ssh_retries }} connect_timeout=5
+  when: (not use_phys_hosts)
+  
 # Kernel 5.8+, because the stock kernel + EPYC CPU = can't start any VM on the host
 - include: ./ubuntu_custom_kernel.yml
   when: ansible_distribution_version|version_compare('20.04','>=')

--- a/Ansible/roles/kvm/tasks/ubuntu_custom_kernel.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu_custom_kernel.yml
@@ -1,8 +1,5 @@
 ---
 
-- debug:
-    msg: "Ubuntu 20 custom kernel v5.9"
-
 - name: Download kernel DEB packages
   shell: /usr/bin/wget http://10.2.0.4/custom-kernels/{{ item }} -P /tmp
   with_items:

--- a/Ansible/roles/kvm/tasks/ubuntu_custom_kernel.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu_custom_kernel.yml
@@ -1,0 +1,25 @@
+---
+
+- debug:
+    msg: "Ubuntu 20 custom kernel v5.9"
+
+- name: Download kernel DEB packages
+  shell: /usr/bin/wget http://10.2.0.4/custom-kernels/{{ item }} -P /tmp
+  with_items:
+    - linux-headers-5.9.0-050900_5.9.0-050900.202010112230_all.deb
+    - linux-headers-5.9.0-050900-generic_5.9.0-050900.202010112230_amd64.deb
+    - linux-image-unsigned-5.9.0-050900-generic_5.9.0-050900.202010112230_amd64.deb
+    - linux-modules-5.9.0-050900-generic_5.9.0-050900.202010112230_amd64.deb
+ 
+- name: Install kernel DEB packages
+  shell: /usr/bin/dpkg -i /tmp/linux-*.deb
+ 
+- name: Reboot KVM host to load new kernel
+  shell: /sbin/reboot
+  async: 0
+  poll: 0
+  ignore_errors: true
+
+- name: wait for ssh
+  local_action: wait_for port=22 host="{{ ansible_ssh_host }}" timeout={{ ssh_retries }} connect_timeout=5
+  when: (not use_phys_hosts)


### PR DESCRIPTION
Install kernel 5.9 by default, for CentOS 8 and Ubuntu 20 - fixing the "qemy can't start any VM on AMD EPYC"
Ansible shell now used (instead of the module) to restart mgmt services after global congif (port 8096) change - since module was failing on Ubuntu 20 and the integration port woild never become active - blocking automatic test runs.