### PR TITLE
Restore tests to execute and fix number of tests executed

### DIFF
--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -51,12 +51,12 @@ retries=12
 remove_old_files
 record_existing_entities
 
-NUMTESTS=`find $TESTDIR -name test_*.py | wc -l`
+NUMTESTS=`ls $TESTDIR/test_*.py | wc -l`
 run_start_time="$(date -u +%s)"
 PASSES=0
 counter=1
 # FIXME: make separate list of `dangerous` tests and those that may be run in parallel
-FILES=$(find $TESTDIR/ -name "test_*py" | grep -v test_host_maintenance | grep -v test_hostha_kvm)
+FILES=$(ls $TESTDIR/test_*py | grep -v test_host_maintenance | grep -v test_hostha_kvm)
 if [ -f /$TESTDIR/test_host_maintenance.py ]; then
     FILES="$FILES $TESTDIR/test_host_maintenance.py"
 fi


### PR DESCRIPTION
The tests under the misc/ directory have been excluded from smoke tests execution for many years, after the latest changes are running and failing:
![image](https://user-images.githubusercontent.com/5295080/131683045-a9ef3938-062e-4d62-8915-882fe5134398.png)
![image](https://user-images.githubusercontent.com/5295080/131683082-d9ac4d1d-63a5-4175-803e-3537eeebf662.png)
