### PR TITLE
Revert "Restore tests to execute and fix number of tests executed"

### DIFF
--- a/Ansible/roles/marvin/templates/smoketests.sh.j2
+++ b/Ansible/roles/marvin/templates/smoketests.sh.j2
@@ -51,12 +51,12 @@ retries=12
 remove_old_files
 record_existing_entities
 
-NUMTESTS=`ls $TESTDIR/test_*.py | wc -l`
+NUMTESTS=`find $TESTDIR -name test_*.py | wc -l`
 run_start_time="$(date -u +%s)"
 PASSES=0
 counter=1
 # FIXME: make separate list of `dangerous` tests and those that may be run in parallel
-FILES=$(ls $TESTDIR/test_*py | grep -v test_host_maintenance | grep -v test_hostha_kvm)
+FILES=$(find $TESTDIR/ -name "test_*py" | grep -v test_host_maintenance | grep -v test_hostha_kvm)
 if [ -f /$TESTDIR/test_host_maintenance.py ]; then
     FILES="$FILES $TESTDIR/test_host_maintenance.py"
 fi


### PR DESCRIPTION
Reverts shapeblue/Trillian#138
as https://github.com/apache/cloudstack/pull/5456 has been merged, this one can be reverted. The find is meant to aid making the test sets to run more componentised so it will be easier to run subsets in the future.