### PR TITLE
Fix Vmware 7 smoke test issues 

### DIFF
--- a/Ansible/roles/marvin/templates/test_data.py.j2
+++ b/Ansible/roles/marvin/templates/test_data.py.j2
@@ -1017,7 +1017,8 @@ test_data = {
             "ostype": "Other Linux (64-bit)",
             "url": "{{ openvm_images_location }}/cloudstack/macchinina/x86_64/macchinina-vmware.ova",
             "requireshvm": "True",
-            "ispublic": "True"
+            "ispublic": "True",
+            "deployasis": "True"
         }
     },
     "test_ovf_templates": [


### PR DESCRIPTION
As seen with @DaanHoogland @weizhouapache, the macchinina template is faulty if not using deploy-as-is on Vmware 7 