### PR TITLE
Start haveged service in management server for entropy support

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/centos.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos.yml
@@ -26,8 +26,14 @@
 - name: Ensure CA Certs are latest
   yum: name=ca-certificates state=latest enablerepo=base
 
-- name: install rng-tools to get entropy
+- name: install haveged to get entropy
   yum: name=haveged state=present
+
+- name: start haveged for entropy
+  service:
+    name: haveged
+    state: started
+    enabled: yes
 
 - name: update lvm2 as fix for bugzilla.redhat.com/show_bug.cgi?id=1294128
   yum: name=lvm2 state=latest

--- a/Ansible/roles/cloudstack-manager/tasks/centos8.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/centos8.yml
@@ -66,8 +66,14 @@
 - name: Ensure CA Certs are latest
   dnf: name=ca-certificates state=latest enablerepo=base
 
-- name: install rng-tools to get entropy
+- name: install haveged to get entropy
   dnf: name=haveged state=present
+
+- name: start haveged for entropy
+  service:
+    name: haveged
+    state: started
+    enabled: yes
 
 - name: determine number of db hosts
   set_fact: num_xen_hosts="{{ groups['xenserver_hosts'] | length }}"


### PR DESCRIPTION
The haveged service is installed to get entropy, but not enabled/started.

Tested the entropy support with volume encryption functionality.

- Before haveged service start

```
# systemctl status haveged
● haveged.service - Entropy Daemon based on the HAVEGE algorithm
   Loaded: loaded (/usr/lib/systemd/system/haveged.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
     Docs: man:haveged(8)
           http://www.issihosts.com/haveged/

MS Logs:
2022-06-01 10:18:13,626 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-3:ctx-678f3dc5 job-29/job-30 ctx-a0c4dfad) (logid:d30f4ba2) Creating and persisting passphrase took: 4 ms for the volume: Vol[3|name=ROOT-3|vm=3|ROOT]
2022-06-01 10:28:01,062 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-5:ctx-56c4e917 job-34/job-35 ctx-e039e427) (logid:4efd1dff) Creating and persisting passphrase took: 568738 ms for the volume: Vol[7|name=ROOT-6|vm=6|ROOT]
2022-06-01 10:30:36,243 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-4:ctx-87a8da59 job-32/job-33 ctx-346a620b) (logid:a2e63940) Creating and persisting passphrase took: 739998 ms for the volume: Vol[5|name=ROOT-5|vm=5|ROOT]
2022-06-01 10:50:37,445 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-6:ctx-a877755f job-37/job-38 ctx-d35dc785) (logid:0b436b62) Creating and persisting passphrase took: 820955 ms for the volume: Vol[8|name=Data01|vm=null|DATADISK]
2022-06-01 10:59:23,531 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-4:ctx-87a8da59 job-32/job-33 ctx-346a620b) (logid:a2e63940) Creating and persisting passphrase took: 705202 ms for the volume: Vol[6|name=DATA-5|vm=5|DATADISK]
```

- After haveged service start

```
# systemctl start haveged
# systemctl status haveged
● haveged.service - Entropy Daemon based on the HAVEGE algorithm
   Loaded: loaded (/usr/lib/systemd/system/haveged.service; disabled; vendor preset: disabled)
   Active: active (running) since Wed 2022-06-01 11:14:05 UTC; 3s ago
     Docs: man:haveged(8)
           http://www.issihosts.com/haveged/
 Main PID: 22912 (haveged)
   CGroup: /system.slice/haveged.service
           └─22912 /usr/sbin/haveged -w 1024 -v 1 --Foreground

Jun 01 11:14:05 pr135-t4273-kvm-centos7-mgmt1 systemd[1]: Started Entropy Daemon based on the HAVEGE algorithm.
Jun 01 11:14:05 pr135-t4273-kvm-centos7-mgmt1 haveged[22912]: haveged: command socket is listening at fd 3
Jun 01 11:14:05 pr135-t4273-kvm-centos7-mgmt1 haveged[22912]: haveged: ver: 1.9.13; arch: x86; vend: GenuineIntel; build: (gcc 4.8.5 ITV); collect: 128K
Jun 01 11:14:05 pr135-t4273-kvm-centos7-mgmt1 haveged[22912]: haveged: cpu: (L4 VC); data: 32K (L4 V); inst: 32K (L4 V); idx: 21/40; sz: 32709/60538
Jun 01 11:14:05 pr135-t4273-kvm-centos7-mgmt1 haveged[22912]: haveged: tot tests(BA8): A:1/1 B:1/1 continuous tests(B):  last entropy estimate 7.99775
Jun 01 11:14:05 pr135-t4273-kvm-centos7-mgmt1 haveged[22912]: haveged: fills: 0, generated: 0

MS Logs:
2022-06-01 11:14:46,384 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-7:ctx-92f13793 job-39/job-40 ctx-ee216d54) (logid:95031c5d) Creating and persisting passphrase took: 13 ms for the volume: Vol[9|name=ROOT-7|vm=7|ROOT]
2022-06-01 11:15:02,617 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-8:ctx-f225353c job-41/job-42 ctx-2e382934) (logid:dcf15f1d) Creating and persisting passphrase took: 4 ms for the volume: Vol[10|name=ROOT-8|vm=8|ROOT]
2022-06-01 11:15:12,916 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-8:ctx-f225353c job-41/job-42 ctx-2e382934) (logid:dcf15f1d) Creating and persisting passphrase took: 3 ms for the volume: Vol[11|name=DATA-8|vm=8|DATADISK]
2022-06-01 11:15:38,369 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-9:ctx-09a9adff job-43/job-44 ctx-92b1b1ee) (logid:f2f51095) Creating and persisting passphrase took: 4 ms for the volume: Vol[12|name=ROOT-10|vm=10|ROOT]
2022-06-01 11:15:58,479 DEBUG [o.a.c.e.o.VolumeOrchestrator] (Work-Job-Executor-10:ctx-e0766e0c job-46/job-47 ctx-e36f83b8) (logid:379026e9) Creating and persisting passphrase took: 3 ms for the volume: Vol[13|name=Data02|vm=null|DATADISK]
```