### PR TITLE
Ignore msrs for suse on amd based servers

### DIFF
--- a/Ansible/roles/kvm/tasks/suse.yml
+++ b/Ansible/roles/kvm/tasks/suse.yml
@@ -84,6 +84,15 @@
     state=stopped
     enabled=no
 
+- name: Check if AMD processors
+  shell: "sed -ne '/^flags/s/^.*: //p' /proc/cpuinfo | egrep -q '(vmx)'"
+  register: amd_virt
+  ignore_errors: true
+
+- name: Ignore msrs if amd processors present on host
+  shell: echo 1 > /sys/module/kvm/parameters/ignore_msrs
+  when: amd_virt.rc == 1
+
 - include: ./add_local_storage.yml
   when: use_local_storage
   tags:


### PR DESCRIPTION
Suse hosts fail to to come up on amd servers, this fix ignores msrs to allow deployment of VMs on OpenSuse based kvm hosts