### PR TITLE
Vol encrypt requirements - Apple test run

### DIFF
--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -72,6 +72,7 @@
     - rpcbind
     - parted
     - vim
+    - wget
   tags:
     - kvm
 
@@ -121,6 +122,26 @@
   tags:
     - kvm
     - kvm-agent
+
+- name: Install centos-release
+  shell: /usr/bin/wget http://10.0.3.122/centos-release/{{ item }} -P /tmp
+  with_items:
+    - centos-release-7-9.2009.0.el7.centos.x86_64.rpm
+
+- name: Cleanup old repos
+  shell: rm /etc/yum.repos.d/CentOS- -f; rpm -ivh --replacepkgs --replacefiles /tmp/centos-release-7-9.2009.0.el7.centos.x86_64.rpm
+
+- name: ensure yum cache is cleared
+  shell: command="yum clean all"      
+
+- name: Ensure centos-release-qemu-ev is installed
+  yum: name=centos-release-qemu-ev state=present
+
+- name: Ensure qemu-kvm-ev is installed
+  yum: name=qemu-kvm-ev state=present
+
+- name: Remove centos-release-qemu-ev
+  shell: "yum remove centos-release-qemu-ev -y"
 
 - name: Update /etc/sysconfig/libvirtd - LIBVIRTD_ARGS
   lineinfile: dest=/etc/sysconfig/libvirtd regexp='LIBVIRTD_ARGS' line='LIBVIRTD_ARGS="--listen"' state=present
@@ -199,6 +220,6 @@
   shell: "echo {{ kvm_password }} | passwd {{ kvm_username }} --stdin"
 
 - include: ./centos_elrepokernel.yml
-  when: kvm_install_elrepo_kernel 
+  #when: kvm_install_elrepo_kernel
   tags:
     - kvm

--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -128,26 +128,6 @@
     - kvm
     - kvm-agent
 
-- name: Install centos-release
-  shell: /usr/bin/wget http://10.0.3.122/centos-release/{{ item }} -P /tmp
-  with_items:
-    - centos-release-7-9.2009.0.el7.centos.x86_64.rpm
-
-- name: Cleanup old repos
-  shell: rm /etc/yum.repos.d/CentOS- -f; rpm -ivh --replacepkgs --replacefiles /tmp/centos-release-7-9.2009.0.el7.centos.x86_64.rpm
-
-- name: ensure yum cache is cleared
-  shell: command="yum clean all"      
-
-- name: Ensure centos-release-qemu-ev is installed
-  yum: name=centos-release-qemu-ev state=present
-
-- name: Ensure qemu-kvm-ev is installed
-  yum: name=qemu-kvm-ev state=present
-
-- name: Remove centos-release-qemu-ev
-  shell: "yum remove centos-release-qemu-ev -y"
-
 - name: Update /etc/sysconfig/libvirtd - LIBVIRTD_ARGS
   lineinfile: dest=/etc/sysconfig/libvirtd regexp='LIBVIRTD_ARGS' line='LIBVIRTD_ARGS="--listen"' state=present
   tags:

--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -224,9 +224,13 @@
   tags:
     - kvm
 
-- name: Install cryptsetup to support encryption
+- name: Install cryptsetup and rng-tools to support encryption and entropy respectively
   yum: name={{ item }} state=present enablerepo=base
   with_items:
     - cryptsetup
+    - rng-tools
   tags:
     - kvm
+
+- name: Start rng service
+  shell: "systemctl start rngd"

--- a/Ansible/roles/kvm/tasks/centos8.yml
+++ b/Ansible/roles/kvm/tasks/centos8.yml
@@ -213,3 +213,14 @@
 # when: kvm_install_elrepo_kernel
   tags:
     - kvm
+
+- name: Install cryptsetup and rng-tools to support encryption and entropy respectively
+  dnf: name={{ item }} state=present enablerepo=base
+  with_items:
+    - cryptsetup
+    - rng-tools
+  tags:
+    - kvm
+
+- name: Start rng service
+  shell: "systemctl start rngd"

--- a/Ansible/tasks/buildvms_custom_allocator.yml
+++ b/Ansible/tasks/buildvms_custom_allocator.yml
@@ -499,6 +499,8 @@
 - name: SSH into VC container and replace vmx file for VC
   shell: "sshpass -p 'P@ssword123' ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@{{ vc_retval.results[0].default_ip }} '{{ item }}'"
   with_items:
+    - "sed -i \"/^ethernet0.address =/d\" $(find -name VC.vmx)"
+    - "sed -i \"/^ethernet0.addressType =/d\" $(find -name VC.vmx)"
     - "echo \"ethernet0.addressType = \"static\"\" >> $(find -name VC.vmx)"
     - "echo \"ethernet0.address = \"{{ dummyVMMAC.stdout }}\"\" >> $(find -name VC.vmx)"
   when: esxi_nested_vcenter
@@ -508,6 +510,7 @@
   with_items:
     - "vim-cmd hostsvc/autostartmanager/enable_autostart 0"
     - "vim-cmd vmsvc/getallvms"
+    - "vim-cmd vmsvc/reload 1"
     - "vim-cmd vmsvc/power.on 1"
   when: esxi_nested_vcenter
   register: vmsout

--- a/Ansible/templates/CentOS-Base.repo.j2
+++ b/Ansible/templates/CentOS-Base.repo.j2
@@ -26,3 +26,11 @@ baseurl={{ os_repo }}/centos/$releasever/updates/$basearch/
 gpgcheck=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
 enabled = {{ update_repo_enabled | default(1) }}
+
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled = {{ update_repo_enabled | default(1) }}

--- a/Ansible/templates/nestedgroupvars.j2
+++ b/Ansible/templates/nestedgroupvars.j2
@@ -355,7 +355,7 @@ esxi_guest_dvs_network_label: "{{ esxi_guest_dvs_network_label | default( def_es
 esxi_public_dvs_network_label: "{{ esxi_public_dvs_network_label | default( def_esxi_public_dvs_network_label ) }}"
 
 # VMware 7 support - deploy vCenter appliance on a dedicated host
-{% if vmware_ver == "70u1" %}esxi_nested_vcenter: yes
+{% if vmware_ver == "70u1" or vmware_ver == "70u2" or vmware_ver == "70u3" %}esxi_nested_vcenter: yes
 esxi_vc_dummy_container: "{{ env_name_clean }}-dummy"
 {% else %}esxi_nested_vcenter: no
 {% endif %}


### PR DESCRIPTION
NOTE: Not sure if we want trillian to install the dependencies or have these packages installed on MS and KVM hosts as part of installing cloudstack-management / cloudstack-agent? As based on my understanding volume encryption would be enabled by default in ACS - and isn't something that's controlled by a Global setting or property.

