### PR TITLE
kvm: do not configure libvirtd to listen on TCP port 16509

### DIFF
--- a/Ansible/roles/kvm/tasks/centos.yml
+++ b/Ansible/roles/kvm/tasks/centos.yml
@@ -119,7 +119,8 @@
   lineinfile: dest=/etc/libvirt/libvirtd.conf regexp={{ item.regexp }} line={{ item.line }}  state=present
   with_items:
     - { regexp: "listen_tls", line: "listen_tls = 0" }
-    - { regexp: "listen_tcp", line: "listen_tcp = 1" }
+    - { regexp: "listen_tcp", line: "listen_tcp = 0" }
+    - { regexp: "tls_port", line: "tcp_port = \"16514\"" }
     - { regexp: "tcp_port", line: "tcp_port = \"16509\"" }
     - { regexp: "auth_tcp", line: "auth_tcp = \"none\"" }
     - { regexp: "mdns_adv", line: "mdns_adv = 0" }
@@ -151,7 +152,7 @@
   with_items:
     - "22"
     - "1798"
-    - "16509"
+    - "16514"
     - "5900:6100"
     - "49152:49216"
   when: ansible_distribution_major_version == "6" or not use_firewalld
@@ -164,7 +165,7 @@
   with_items:
     - "22"
     - "1798"
-    - "16509"
+    - "16514"
     - "5900-6100"
     - "49152-49216"
   when: ( ansible_distribution_major_version == "7" ) and use_firewalld

--- a/Ansible/roles/kvm/tasks/centos8.yml
+++ b/Ansible/roles/kvm/tasks/centos8.yml
@@ -134,7 +134,8 @@
   lineinfile: dest=/etc/libvirt/libvirtd.conf regexp={{ item.regexp }} line={{ item.line }}  state=present
   with_items:
     - { regexp: "listen_tls", line: "listen_tls = 0" }
-    - { regexp: "listen_tcp", line: "listen_tcp = 1" }
+    - { regexp: "listen_tcp", line: "listen_tcp = 0" }
+    - { regexp: "tls_port", line: "tcp_port = \"16514\"" }
     - { regexp: "tcp_port", line: "tcp_port = \"16509\"" }
     - { regexp: "auth_tcp", line: "auth_tcp = \"none\"" }
     - { regexp: "mdns_adv", line: "mdns_adv = 0" }
@@ -162,7 +163,7 @@
   with_items:
     - "22"
     - "1798"
-    - "16509"
+    - "16514"
     - "5900:6100"
     - "49152:49216"
   when: ansible_distribution_major_version == "6" or not use_firewalld
@@ -175,7 +176,7 @@
   with_items:
     - "22"
     - "1798"
-    - "16509"
+    - "16514"
     - "5900-6100"
     - "49152-49216"
   when: ( ansible_distribution_major_version|int >= 7 ) and use_firewalld

--- a/Ansible/roles/kvm/tasks/suse.yml
+++ b/Ansible/roles/kvm/tasks/suse.yml
@@ -116,7 +116,8 @@
   lineinfile: dest=/etc/libvirt/libvirtd.conf regexp={{ item.regexp }} line={{ item.line }}  state=present
   with_items:
     - { regexp: "listen_tls", line: "listen_tls = 0" }
-    - { regexp: "listen_tcp", line: "listen_tcp = 1" }
+    - { regexp: "listen_tcp", line: "listen_tcp = 0" }
+    - { regexp: "tls_port", line: "tcp_port = \"16514\"" }
     - { regexp: "tcp_port", line: "tcp_port = \"16509\"" }
     - { regexp: "auth_tcp", line: "auth_tcp = \"none\"" }
     - { regexp: "mdns_adv", line: "mdns_adv = 0" }
@@ -144,7 +145,7 @@
   with_items:
     - "22"
     - "1798"
-    - "16509"
+    - "16514"
     - "5900:6100"
     - "49152:49216"
   when: not use_firewalld
@@ -157,7 +158,7 @@
   with_items:
     - "22"
     - "1798"
-    - "16509"
+    - "16514"
     - "5900-6100"
     - "49152-49216"
   when: use_firewalld

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -225,7 +225,7 @@
   with_items:
     - "22"
     - "1798"
-    - "16509"
+    - "16514"
     - "5900:6100"
     - "49152:49216"
 
@@ -298,7 +298,10 @@
   lineinfile: dest=/etc/libvirt/libvirtd.conf regexp="#listen_tls = 0" line="listen_tls = 0"
 
 - name: Updated /etc/libvirt/libvirtd.conf
-  lineinfile: dest=/etc/libvirt/libvirtd.conf regexp='#listen_tcp = 1' line='listen_tcp = 1'
+  lineinfile: dest=/etc/libvirt/libvirtd.conf regexp='#listen_tcp = 1' line='listen_tcp = 0'
+
+- name: Updated /etc/libvirt/libvirtd.conf
+  lineinfile: dest=/etc/libvirt/libvirtd.conf regexp='#tls_port= "16514"' line='tls_port = "16514"'
 
 - name: Updated /etc/libvirt/libvirtd.conf
   lineinfile: dest=/etc/libvirt/libvirtd.conf regexp='#tcp_port= "16509"' line='tcp_port = "16509"'


### PR DESCRIPTION
This is the trillian setting for 
https://github.com/apache/cloudstack-documentation/pull/301
KVM: do not listen on TCP port when configure kvm host #301

