### PR TITLE
Use cmk deleteProject instead of cs_project module

### DIFF
--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -94,6 +94,6 @@
   shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
   register: projectid
 
-- name: Delete project (using cmk, with "cleanup")
+- name: Delete project (using cmk, with cleanup)
   shell: cmk deleteproject id={{ projectid }} cleanup=true
   

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -94,7 +94,5 @@
 - name: get projectid
   shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
   register: projectid
-#- debug: msg="{{ projectid.stdout }}"
-
 - name: Delete project (using cmk, with cleanup)
   shell: "cmk deleteproject id={{ projectid.stdout }} cleanup=true"

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -94,6 +94,6 @@
   shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
   register: projectid
 
-- name: Delete project (using cmk, with "cleanup)
+- name: Delete project (using cmk, with "cleanup")
   shell: cmk deleteproject id={{ projectid }} cleanup=true
   

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -91,7 +91,7 @@
 #  ignore_errors: yes
 ####################################################################
 - name: get projectid
-  shell: "cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'"
+  shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
   register: projectid
 - debug: msg="{{ projectid.stdout }}"
 

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -96,3 +96,4 @@
 	  
 - name: Delete project (using cmk, with "cleanup)
   shell: cmk deleteproject id={{ build_project }} cleanup=true
+  

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -95,5 +95,4 @@
   register: projectid
 
 - name: Delete project (using cmk, with cleanup)
-  shell: cmk deleteproject id={{ projectid }} cleanup=true
-  
+  shell: cmk deleteproject id={{ projectid.stdout }} cleanup=true

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -91,8 +91,9 @@
 #  ignore_errors: yes
 ####################################################################
 - name: get projectid
-  shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
+  shell: "cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'"
   register: projectid
+- debug: msg="{{ projectid.stdout }}"
 
 - name: Delete project (using cmk, with cleanup)
-  shell: cmk deleteproject id={{ projectid.stdout }} cleanup=true
+  shell: "cmk deleteproject id={{ projectid.stdout }} cleanup=true"

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -75,15 +75,24 @@
 #   ignore_errors: yes
 
 
+#####################################################################
+## cs_project doesn't support cleanup=true parameter, so can't delete manually created resources
+## that are not manually destroyed
+##
+## Remove project
+##
+#- name: Delete project
+#  local_action:
+#    module: cs_project
+#    name: "{{ build_project }}"
+#    state: absent
+#    api_timeout: 120
+#  when: (removeproject is defined) or destroy_forced
+#  ignore_errors: yes
 ####################################################################
-# Remove project
-#
-- name: Delete project
-  local_action:
-    module: cs_project
-    name: "{{ build_project }}"
-    state: absent
-    api_timeout: 120
-  when: (removeproject is defined) or destroy_forced
-  ignore_errors: yes
-####################################################################
+- name: get projectid
+  shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
+  register: projectid
+	  
+- name: Delete project (using cmk, with "cleanup)
+  shell: cmk deleteproject id={{ build_project }} cleanup=true

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -93,7 +93,7 @@
 - name: get projectid
   shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
   register: projectid
-	  
+
 - name: Delete project (using cmk, with "cleanup)
-  shell: cmk deleteproject id={{ build_project }} cleanup=true
+  shell: cmk deleteproject id={{ projectid }} cleanup=true
   

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -90,14 +90,11 @@
 #  when: (removeproject is defined) or destroy_forced
 #  ignore_errors: yes
 ####################################################################
-#- name: config
-#  shell: cat .cmk/config
-- name: hostname show
-  shell: hostname --fqdn
-#- name: get projectid
-#  shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
-#  register: projectid
+
+- name: get projectid
+  shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
+  register: projectid
 #- debug: msg="{{ projectid.stdout }}"
-#
-#- name: Delete project (using cmk, with cleanup)
-#  shell: "cmk deleteproject id={{ projectid.stdout }} cleanup=true"
+
+- name: Delete project (using cmk, with cleanup)
+  shell: "cmk deleteproject id={{ projectid.stdout }} cleanup=true"

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -90,15 +90,14 @@
 #  when: (removeproject is defined) or destroy_forced
 #  ignore_errors: yes
 ####################################################################
-- name: listZone
-  shell: cmk listZones
-  register: zoneid
-- debug: msg="{{ zoneid.stdout }}"
-
-- name: get projectid
-  shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
-  register: projectid
-- debug: msg="{{ projectid.stdout }}"
-
-- name: Delete project (using cmk, with cleanup)
-  shell: "cmk deleteproject id={{ projectid.stdout }} cleanup=true"
+- name: config
+  shell: cat .cmk/config
+- name: hostname show
+  shell: hostname --fqdn
+#- name: get projectid
+#  shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
+#  register: projectid
+#- debug: msg="{{ projectid.stdout }}"
+#
+#- name: Delete project (using cmk, with cleanup)
+#  shell: "cmk deleteproject id={{ projectid.stdout }} cleanup=true"

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -90,8 +90,8 @@
 #  when: (removeproject is defined) or destroy_forced
 #  ignore_errors: yes
 ####################################################################
-- name: config
-  shell: cat .cmk/config
+#- name: config
+#  shell: cat .cmk/config
 - name: hostname show
   shell: hostname --fqdn
 #- name: get projectid

--- a/Ansible/tasks/removeproject.yml
+++ b/Ansible/tasks/removeproject.yml
@@ -90,6 +90,11 @@
 #  when: (removeproject is defined) or destroy_forced
 #  ignore_errors: yes
 ####################################################################
+- name: listZone
+  shell: cmk listZones
+  register: zoneid
+- debug: msg="{{ zoneid.stdout }}"
+
 - name: get projectid
   shell: cmk listProjects | jq -c '.project[] | select(.name | contains("{{ build_project }}"))' | jq '.id'
   register: projectid


### PR DESCRIPTION
... since "cleanup=true" is required to wipe any manually-created data inside the project (4.16+ requires cleanup=true, vs previously doing it silently without the (unexisting at that time) parameter