### PR TITLE
Remove elrepo kernel as default in EL8 and EL9

### DIFF
--- a/Ansible/roles/kvm/tasks/centos8.yml
+++ b/Ansible/roles/kvm/tasks/centos8.yml
@@ -215,6 +215,6 @@
   shell: "echo {{ kvm_password }} | passwd {{ kvm_username }} --stdin"
 
 - include: ./centos_elrepokernel.yml
-# when: kvm_install_elrepo_kernel
+  when: kvm_install_elrepo_kernel
   tags:
     - kvm

--- a/Ansible/roles/kvm/tasks/el9.yml
+++ b/Ansible/roles/kvm/tasks/el9.yml
@@ -226,6 +226,6 @@
   shell: "echo {{ kvm_password }} | passwd {{ kvm_username }} --stdin"
 
 - include: ./centos_elrepokernel.yml
-# when: kvm_install_elrepo_kernel
+  when: kvm_install_elrepo_kernel
   tags:
     - kvm


### PR DESCRIPTION
Remove elrepo kernel as default in EL8 and EL9. It has bugs on our infra leading to high CPU usage in the guest blamed on scsi_eh_0 as well as huge log files on the hypervisor.