### PR TITLE
marvin: fix pip ssl error

### DIFF
--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -100,7 +100,7 @@
 - name: Update pip and components
   pip:
     name: "{{ item }}"
-    extra_args: '--upgrade'
+    extra_args: '--trusted-host pypi.org --trusted-host pypi.python.org --trusted-host files.pythonhosted.org --upgrade'
   with_items:
   - pip==20.2.1
   - six


### PR DESCRIPTION
Fixes SSL error while installing python pip packages during marvin VM deployment seen in:
http://sl-jenkins-master.sofia.shapeblue.com:8080/job/acs-pr-trillian/10216/console
http://sl-jenkins-master.sofia.shapeblue.com:8080/job/acs-pr-trillian/10220/console
and more

Successful job: http://sl-jenkins-master.sofia.shapeblue.com:8080/job/acs-pr-trillian/10225/console