### PR TITLE
let latest python connector be used

### DIFF
--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -137,7 +137,7 @@
   - lxml
   - pycparser==2.13
   - paramiko
-  - mysql-connector-python==8.0.29
+  - mysql-connector-python
   - netaddr==0.10.1
   tags:
     - marvin


### PR DESCRIPTION
lately a lot of connector errors occur:
```
...
  File "/usr/local/lib/python3.6/site-packages/marvin/dbConnection.py", line 45, in execute
    db=str(self.database) if not db else db)) as conn:
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/pooling.py", line 287, in connect
    return MySQLConnection(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/connection.py", line 137, in __init__
    self.connect(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/abstracts.py", line 1095, in connect
    self._open_connection()
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/connection.py", line 544, in _open_connection
    self.set_converter_class(self._converter_class)
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/abstracts.py", line 1271, in set_converter_class
    self.converter = convclass(charset_name, self._use_unicode)
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/conversion.py", line 136, in __init__
    MySQLConverterBase.__init__(self, charset, use_unicode, str_fallback)
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/conversion.py", line 59, in __init__
    self.set_charset(charset)
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/conversion.py", line 73, in set_charset
    self.charset_id = CharacterSet.get_charset_info(self.charset)[0]
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/constants.py", line 775, in get_charset_info
    info = cls.get_default_collation(charset)
  File "/usr/local/lib/python3.6/site-packages/mysql/connector/constants.py", line 746, in get_default_collation
    raise ProgrammingError(f"Character set '{charset}' unsupported")
mysql.connector.errors.ProgrammingError: Character set 'utf8' unsupported
```

as this is inspite of 8.0.29 being used, (see https://stackoverflow.com/a/73254598/3417287) I can see 8.0.31 being uninstalled. The post shows that 8.0.30 is the disfuct one. In out envs 8.0.29 seems to not function. 