### PR TITLE
Set backup.framework.enabled config to true

### DIFF
--- a/Ansible/group_vars/all.sample
+++ b/Ansible/group_vars/all.sample
@@ -839,6 +839,7 @@ global_settings:
     - {name: "kvm.ha.recover.failure.threshold", value: "2", condition: "all"}
     - {name: "kvm.ha.recover.timeout", value: "30", condition: "all"}
     - {name: "kvm.ha.recover.wait.period", value: "30", condition: "all"}
+    - {name: "backup.framework.enabled", value: "true", condition: "all"}
   marvin:
     - {name: "ping.interval", value: "20", condition: "marvin"}
     - {name: "ping.timeout", value: "2.0", condition: "marvin"}


### PR DESCRIPTION
Needed for newly added Nas backup integration test in https://github.com/apache/cloudstack/pull/10140