### PR TITLE
marvin: Stop and disable firewalld on OL9

### DIFF
--- a/Ansible/roles/marvin/tasks/main.yml
+++ b/Ansible/roles/marvin/tasks/main.yml
@@ -18,6 +18,10 @@
 - name: Set hostname pt2
   shell: "hostnamectl set-hostname {{ inventory_hostname }}"
 
+- name: Stop and disable firewalld on OL9
+  shell: systemctl stop firewalld && systemctl disable firewalld
+  ignore_errors: true
+
 - name: Ensure selinux python3 bindings are installed
   dnf: name=python3-libselinux state=present
 


### PR DESCRIPTION
this fixes the issue with trillian test failures
- test_outofbandmanagement_nestedplugin.py
- test_webhook_delivery.py