### PR TITLE
Update Cloud-init template for VMware

### DIFF
--- a/Ansible/roles/marvin/templates/test_data.py.j2
+++ b/Ansible/roles/marvin/templates/test_data.py.j2
@@ -1139,7 +1139,7 @@ test_data = {
             "format": "ova",
             "hypervisor": "vmware",
             "ostype": "Other Linux (64-bit)",
-            "url": "https://cloud-images.ubuntu.com/releases/jammy/release/ubuntu-22.04-server-cloudimg-amd64.ova",
+            "url": "http://{{ stagingserverip }}/templates/ubuntu24-cloud-image-root-password-with-tools.ova",
             "requireshvm": "True",
             "ispublic": "True",
             "deployasis": "False"


### PR DESCRIPTION
This uses the same ubnutu 24.04 cloud image for testing on xenserver and vmware

