### PR TITLE
Fix SUSE15 CloudStack package install: version pinning and Python 3 support

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
@@ -18,7 +18,7 @@
   template: src=cloudstack.repo.j2 dest=/etc/zypp/repos.d/cloudstack.repo
 
 - name: Ensure CloudStack packages are installed
-  shell: "zypper install -y {{ cloudstack_management_package }}* {{ cloudstack_common_package }}*"
+  shell: "zypper install -y {{ ('cloudstack-management>=' + env_cs_numeric_version) if cloudstack_management_package != 'cloudstack-management' else 'cloudstack-management' }} {{ ('cloudstack-common>=' + env_cs_numeric_version) if cloudstack_common_package != 'cloudstack-common' else 'cloudstack-common' }}"
 
 - name: Ensure MySQL Client is present
   shell: "zypper install -y mysql"
@@ -41,7 +41,7 @@
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
 
 - name: Ensure CloudStack Usage Service is installed
-  shell: "zypper install -y {{ cloudstack_usage_package }}*"
+  shell: "zypper install -y {{ ('cloudstack-usage>=' + env_cs_numeric_version) if cloudstack_usage_package != 'cloudstack-usage' else 'cloudstack-usage' }}"
 
 - include: ./setupdb.yml
 

--- a/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
@@ -17,14 +17,30 @@
 - name: "Setup Apache Cloudstack Repo file. baseurl={{ baseurl_cloudstack }} "
   template: src=cloudstack.repo.j2 dest=/etc/zypp/repos.d/cloudstack.repo
 
-- name: Ensure CloudStack packages are installed
+- name: Get exact CloudStack package version from repo
+  shell: "zypper -q search -s --match-exact cloudstack-common | awk -F'|' '{gsub(/ /,\"\",$4); if($4~/^{{ env_cs_numeric_version }}/) print $4}' | head -1"
+  register: cloudstack_suse_version
+  when: cloudstack_management_package != 'cloudstack-management'
+
+- name: Ensure CloudStack packages are installed (version pinned)
   command:
     argv:
       - zypper
       - install
       - -y
-      - "{{ cloudstack_management_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_management_package is match('.*-\\d') else '' }}"
-      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_common_package is match('.*-\\d') else '' }}"
+      - "{{ cloudstack_management_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
+      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
+  when: cloudstack_management_package != 'cloudstack-management'
+
+- name: Ensure CloudStack packages are installed (latest)
+  command:
+    argv:
+      - zypper
+      - install
+      - -y
+      - "{{ cloudstack_management_package }}"
+      - "{{ cloudstack_common_package }}"
+  when: cloudstack_management_package == 'cloudstack-management'
 
 - name: Ensure MySQL Client is present
   shell: "zypper install -y mysql"
@@ -46,13 +62,28 @@
 - name: Ensure vhd-util is present
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
 
-- name: Ensure CloudStack Usage Service is installed
+- name: Get exact CloudStack usage package version from repo
+  shell: "zypper -q search -s --match-exact cloudstack-usage | awk -F'|' '{gsub(/ /,\"\",$4); if($4~/^{{ env_cs_numeric_version }}/) print $4}' | head -1"
+  register: cloudstack_suse_usage_version
+  when: cloudstack_usage_package != 'cloudstack-usage'
+
+- name: Ensure CloudStack Usage Service is installed (version pinned)
   command:
     argv:
       - zypper
       - install
       - -y
-      - "{{ cloudstack_usage_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_usage_package is match('.*-\\d') else '' }}"
+      - "{{ cloudstack_usage_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_usage_version.stdout }}"
+  when: cloudstack_usage_package != 'cloudstack-usage'
+
+- name: Ensure CloudStack Usage Service is installed (latest)
+  command:
+    argv:
+      - zypper
+      - install
+      - -y
+      - "{{ cloudstack_usage_package }}"
+  when: cloudstack_usage_package == 'cloudstack-usage'
 
 - include: ./setupdb.yml
 

--- a/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
@@ -18,7 +18,13 @@
   template: src=cloudstack.repo.j2 dest=/etc/zypp/repos.d/cloudstack.repo
 
 - name: Ensure CloudStack packages are installed
-  shell: "zypper install -y {{ ('cloudstack-management>=' + env_cs_numeric_version) if cloudstack_management_package != 'cloudstack-management' else 'cloudstack-management' }} {{ ('cloudstack-common>=' + env_cs_numeric_version) if cloudstack_common_package != 'cloudstack-common' else 'cloudstack-common' }}"
+  command:
+    argv:
+      - zypper
+      - install
+      - -y
+      - "{{ cloudstack_management_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_management_package is match('.*-\\d') else '' }}"
+      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_common_package is match('.*-\\d') else '' }}"
 
 - name: Ensure MySQL Client is present
   shell: "zypper install -y mysql"
@@ -41,7 +47,12 @@
   get_url: url="{{ vhdutil_url }}" dest=/usr/share/cloudstack-common/scripts/vm/hypervisor/xenserver/vhd-util mode=0755
 
 - name: Ensure CloudStack Usage Service is installed
-  shell: "zypper install -y {{ ('cloudstack-usage>=' + env_cs_numeric_version) if cloudstack_usage_package != 'cloudstack-usage' else 'cloudstack-usage' }}"
+  command:
+    argv:
+      - zypper
+      - install
+      - -y
+      - "{{ cloudstack_usage_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_usage_package is match('.*-\\d') else '' }}"
 
 - include: ./setupdb.yml
 

--- a/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
@@ -23,23 +23,11 @@
   when: cloudstack_management_package != 'cloudstack-management'
 
 - name: Ensure CloudStack packages are installed (version pinned)
-  command:
-    argv:
-      - zypper
-      - install
-      - -y
-      - "{{ cloudstack_management_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
-      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
+  shell: "zypper install -y {{ cloudstack_management_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }} {{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
   when: cloudstack_management_package != 'cloudstack-management'
 
 - name: Ensure CloudStack packages are installed (latest)
-  command:
-    argv:
-      - zypper
-      - install
-      - -y
-      - "{{ cloudstack_management_package }}"
-      - "{{ cloudstack_common_package }}"
+  shell: "zypper install -y {{ cloudstack_management_package }} {{ cloudstack_common_package }}"
   when: cloudstack_management_package == 'cloudstack-management'
 
 - name: Ensure MySQL Client is present
@@ -68,21 +56,11 @@
   when: cloudstack_usage_package != 'cloudstack-usage'
 
 - name: Ensure CloudStack Usage Service is installed (version pinned)
-  command:
-    argv:
-      - zypper
-      - install
-      - -y
-      - "{{ cloudstack_usage_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_usage_version.stdout }}"
+  shell: "zypper install -y {{ cloudstack_usage_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_usage_version.stdout }}"
   when: cloudstack_usage_package != 'cloudstack-usage'
 
 - name: Ensure CloudStack Usage Service is installed (latest)
-  command:
-    argv:
-      - zypper
-      - install
-      - -y
-      - "{{ cloudstack_usage_package }}"
+  shell: "zypper install -y {{ cloudstack_usage_package }}"
   when: cloudstack_usage_package == 'cloudstack-usage'
 
 - include: ./setupdb.yml

--- a/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/suse-acs.yml
@@ -20,6 +20,8 @@
 - name: Get exact CloudStack package version from repo
   shell: "zypper -q search -s --match-exact cloudstack-common | awk -F'|' '{gsub(/ /,\"\",$4); if($4~/^{{ env_cs_numeric_version }}/) print $4}' | head -1"
   register: cloudstack_suse_version
+  changed_when: false
+  failed_when: cloudstack_suse_version.rc != 0 or cloudstack_suse_version.stdout | trim == ''
   when: cloudstack_management_package != 'cloudstack-management'
 
 - name: Ensure CloudStack packages are installed (version pinned)
@@ -53,6 +55,8 @@
 - name: Get exact CloudStack usage package version from repo
   shell: "zypper -q search -s --match-exact cloudstack-usage | awk -F'|' '{gsub(/ /,\"\",$4); if($4~/^{{ env_cs_numeric_version }}/) print $4}' | head -1"
   register: cloudstack_suse_usage_version
+  changed_when: false
+  failed_when: cloudstack_suse_usage_version.rc != 0 or cloudstack_suse_usage_version.stdout | trim == ''
   when: cloudstack_usage_package != 'cloudstack-usage'
 
 - name: Ensure CloudStack Usage Service is installed (version pinned)

--- a/Ansible/roles/kvm/tasks/suse-acs.yml
+++ b/Ansible/roles/kvm/tasks/suse-acs.yml
@@ -27,11 +27,19 @@
 - name: Get exact CloudStack package version from repo
   shell: "zypper -q search -s --match-exact cloudstack-common | awk -F'|' '{gsub(/ /,\"\",$4); if($4~/^{{ env_cs_numeric_version }}/) print $4}' | head -1"
   register: cloudstack_suse_version
+  changed_when: false
+  failed_when: cloudstack_suse_version.rc != 0 or cloudstack_suse_version.stdout | trim == ''
   when: cloudstack_agent_package != 'cloudstack-agent'
+  tags:
+    - kvm
+    - kvm-agent
 
 - name: Ensure CloudStack packages are installed (version pinned)
   shell: "zypper install -y {{ cloudstack_agent_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }} {{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
   when: cloudstack_agent_package != 'cloudstack-agent'
+  tags:
+    - kvm
+    - kvm-agent
 
 - name: Ensure CloudStack packages are installed (latest)
   shell: "zypper install -y {{ cloudstack_agent_package }} {{ cloudstack_common_package }}"

--- a/Ansible/roles/kvm/tasks/suse-acs.yml
+++ b/Ansible/roles/kvm/tasks/suse-acs.yml
@@ -30,23 +30,11 @@
   when: cloudstack_agent_package != 'cloudstack-agent'
 
 - name: Ensure CloudStack packages are installed (version pinned)
-  command:
-    argv:
-      - zypper
-      - install
-      - -y
-      - "{{ cloudstack_agent_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
-      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
+  shell: "zypper install -y {{ cloudstack_agent_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }} {{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
   when: cloudstack_agent_package != 'cloudstack-agent'
 
 - name: Ensure CloudStack packages are installed (latest)
-  command:
-    argv:
-      - zypper
-      - install
-      - -y
-      - "{{ cloudstack_agent_package }}"
-      - "{{ cloudstack_common_package }}"
+  shell: "zypper install -y {{ cloudstack_agent_package }} {{ cloudstack_common_package }}"
   when: cloudstack_agent_package == 'cloudstack-agent'
   tags:
     - kvm

--- a/Ansible/roles/kvm/tasks/suse-acs.yml
+++ b/Ansible/roles/kvm/tasks/suse-acs.yml
@@ -25,7 +25,13 @@
     - kvm-agent
 
 - name: Ensure CloudStack packages are installed
-  shell: "zypper install -y {{ ('cloudstack-agent>=' + env_cs_numeric_version) if cloudstack_agent_package != 'cloudstack-agent' else 'cloudstack-agent' }} {{ ('cloudstack-common>=' + env_cs_numeric_version) if cloudstack_common_package != 'cloudstack-common' else 'cloudstack-common' }}"
+  command:
+    argv:
+      - zypper
+      - install
+      - -y
+      - "{{ cloudstack_agent_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_agent_package is match('.*-\\d') else '' }}"
+      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_common_package is match('.*-\\d') else '' }}"
   tags:
     - kvm
     - kvm-agent

--- a/Ansible/roles/kvm/tasks/suse-acs.yml
+++ b/Ansible/roles/kvm/tasks/suse-acs.yml
@@ -25,7 +25,7 @@
     - kvm-agent
 
 - name: Ensure CloudStack packages are installed
-  shell: "zypper install -y {{ cloudstack_agent_package }}* {{ cloudstack_common_package }}*"
+  shell: "zypper install -y {{ ('cloudstack-agent>=' + env_cs_numeric_version) if cloudstack_agent_package != 'cloudstack-agent' else 'cloudstack-agent' }} {{ ('cloudstack-common>=' + env_cs_numeric_version) if cloudstack_common_package != 'cloudstack-common' else 'cloudstack-common' }}"
   tags:
     - kvm
     - kvm-agent

--- a/Ansible/roles/kvm/tasks/suse-acs.yml
+++ b/Ansible/roles/kvm/tasks/suse-acs.yml
@@ -24,14 +24,30 @@
     - kvm
     - kvm-agent
 
-- name: Ensure CloudStack packages are installed
+- name: Get exact CloudStack package version from repo
+  shell: "zypper -q search -s --match-exact cloudstack-common | awk -F'|' '{gsub(/ /,\"\",$4); if($4~/^{{ env_cs_numeric_version }}/) print $4}' | head -1"
+  register: cloudstack_suse_version
+  when: cloudstack_agent_package != 'cloudstack-agent'
+
+- name: Ensure CloudStack packages are installed (version pinned)
   command:
     argv:
       - zypper
       - install
       - -y
-      - "{{ cloudstack_agent_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_agent_package is match('.*-\\d') else '' }}"
-      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}{{ '>=' + env_cs_numeric_version if cloudstack_common_package is match('.*-\\d') else '' }}"
+      - "{{ cloudstack_agent_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
+      - "{{ cloudstack_common_package | regex_replace('-\\d.*$', '') }}={{ cloudstack_suse_version.stdout }}"
+  when: cloudstack_agent_package != 'cloudstack-agent'
+
+- name: Ensure CloudStack packages are installed (latest)
+  command:
+    argv:
+      - zypper
+      - install
+      - -y
+      - "{{ cloudstack_agent_package }}"
+      - "{{ cloudstack_common_package }}"
+  when: cloudstack_agent_package == 'cloudstack-agent'
   tags:
     - kvm
     - kvm-agent

--- a/Ansible/templates/nestedinventory.j2
+++ b/Ansible/templates/nestedinventory.j2
@@ -40,7 +40,7 @@ mysql_slave_hosts
 primary_cs_manager
 secondary_cs_manager
 
-{% if mgmt_os | lower == "u18" %}
+{% if mgmt_os | lower == "u18" or mgmt_os | lower == "s15" %}
 [mysql_hosts:vars]
 ansible_python_interpreter=/usr/bin/python3
 
@@ -122,7 +122,7 @@ ansible_python_interpreter=/usr/bin/python3
 {% endfor %}
 {% endif %}
 {% endif %}
-{% if kvm_os | lower == "u18" %}
+{% if kvm_os | lower == "u18" or kvm_os | lower == "s15" %}
 [kvm_hosts:vars]
 ansible_python_interpreter=/usr/bin/python3
 {% endif %}


### PR DESCRIPTION
 Two issues prevented SUSE15 builds from working correctly with specific versions (e.g. cs4.20.0):

  1. **zypper wildcard install failure** zypper does not support cloudstack-management-4.20.0* as a package name — it treats it as a literal string and fails with 'No provider found'. 
  
  **Fix:** query the repo first with zypper search to find the exact version string (e.g. 4.20.0.0-shapeblue0), then install with the = exact-version operator.

  2. **Python interpreter missing SUSE15 ships with Python 3 only.** Ansible's default discovery looks for /usr/bin/python (Python 2), causing all module tasks to fail. 
  
  **Fix**: set ansible_python_interpreter=/usr/bin/python3 for s15 hosts in nestedinventory.j2, matching the existing u18 pattern