### PR TITLE
 Fix Debian/Ubuntu CloudStack version pinning and wheel package compatibility

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/debian.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/debian.yml
@@ -82,13 +82,24 @@
 - name: Install python3-mysql.connector DEB package for cloudstack-management as the real package name is mysql-connector-python-py3
   shell: 'wget http://launchpadlibrarian.net/717081070/python3-mysql.connector_8.0.15-4_all.deb -O /tmp/python3-mysql.connector_8.0.15-4_all.deb && DEBIAN_FRONTEND=noninteractive apt install -y /tmp/python3-mysql.connector_8.0.15-4_all.deb'
 
+- name: get CloudStack package version (for example, 4.20.2.0-shapeblue0)
+  shell: |
+    set -o pipefail
+    apt list -a cloudstack-common | awk '{print $2}' | grep '^{{ env_cs_security_version }}' | sort -Vr | head -n1
+  args:
+    executable: /bin/bash
+  register: cloudstack_package_version
+  changed_when: false
+  failed_when: cloudstack_package_version.stdout | trim | length == 0
+
 - name: Ensure CloudStack management-server only is installed (we install usage server later)
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item }}={{ cloudstack_package_version.stdout }}"
     state: present
     allow_unauthenticated: yes
   with_items:
     - cloudstack-management
+    - cloudstack-common
 
 # no need to remove - same as for CentOS
 #- name: remove CloudStack repository into sources list.
@@ -116,7 +127,7 @@
 
 - name: Ensure CloudStack packages are installed (now that mgmt server "db.properties" and "key" files are present)
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item }}={{ cloudstack_package_version.stdout }}"
     state: present
     allow_unauthenticated: yes
   with_items:

--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -80,13 +80,18 @@
 - name: update apt cache
   shell: "apt update"
 
+- name: get CloudStack package version (for example, 4.20.2.0-shapeblue0)
+  shell: "apt list -a cloudstack-common |awk '{print $2}' |grep '^{{ env_cs_security_version }}' |head -n1"
+  register: cloudstack_package_version
+
 - name: Ensure CloudStack management-server only is installed (we install usage server later)
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item }}={{ cloudstack_package_version.stdout }}"
     state: present
     allow_unauthenticated: yes
   with_items:
     - cloudstack-management
+    - cloudstack-common
 
 # no need to remove - same as for CentOS
 #- name: remove CloudStack repository into sources list.
@@ -112,7 +117,7 @@
 
 - name: Ensure CloudStack packages are installed (now that mgmt server "db.properties" and "key" files are present)
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item }}={{ cloudstack_package_version.stdout }}"
     state: present
     allow_unauthenticated: yes
   with_items:

--- a/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/ubuntu.yml
@@ -81,8 +81,14 @@
   shell: "apt update"
 
 - name: get CloudStack package version (for example, 4.20.2.0-shapeblue0)
-  shell: "apt list -a cloudstack-common |awk '{print $2}' |grep '^{{ env_cs_security_version }}' |head -n1"
+  shell: |
+    set -o pipefail
+    apt list -a cloudstack-common | awk '{print $2}' | grep '^{{ env_cs_security_version }}' | sort -Vr | head -n1
+  args:
+    executable: /bin/bash
   register: cloudstack_package_version
+  changed_when: false
+  failed_when: cloudstack_package_version.stdout | trim | length == 0
 
 - name: Ensure CloudStack management-server only is installed (we install usage server later)
   apt:

--- a/Ansible/roles/kvm/tasks/debian.yml
+++ b/Ansible/roles/kvm/tasks/debian.yml
@@ -211,9 +211,19 @@
   apt:
     update_cache: yes
 
+- name: get CloudStack package version (for example, 4.20.2.0-shapeblue0)
+  shell: |
+    set -o pipefail
+    apt list -a cloudstack-common | awk '{print $2}' | grep '^{{ env_cs_security_version }}' | head -n1
+  args:
+    executable: /bin/bash
+  register: cloudstack_package_version
+  changed_when: false
+  failed_when: cloudstack_package_version.stdout | length == 0
+
 - name: Installs cloudstack-agent
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item }}={{ cloudstack_package_version.stdout }}"
     state: present
     allow_unauthenticated: yes
   with_items:

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -270,9 +270,13 @@
   apt:
     update_cache: yes
 
+- name: get CloudStack package version (for example, 4.20.2.0-shapeblue0)
+  shell: "apt list -a cloudstack-common |awk '{print $2}' |grep '^{{ env_cs_security_version }}' |head -n1"
+  register: cloudstack_package_version
+
 - name: Installs cloudstack-agent
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ item }}={{ cloudstack_package_version.stdout }}"
     state: present
     allow_unauthenticated: yes
   with_items:

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -271,8 +271,14 @@
     update_cache: yes
 
 - name: get CloudStack package version (for example, 4.20.2.0-shapeblue0)
-  shell: "apt list -a cloudstack-common |awk '{print $2}' |grep '^{{ env_cs_security_version }}' |head -n1"
+  shell: |
+    set -o pipefail
+    apt list -a cloudstack-common | awk '{print $2}' | grep '^{{ env_cs_security_version }}' | head -n1
+  args:
+    executable: /bin/bash
   register: cloudstack_package_version
+  changed_when: false
+  failed_when: cloudstack_package_version.stdout | length == 0
 
 - name: Installs cloudstack-agent
   apt:

--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -93,7 +93,7 @@
   - six
   - pyOpenSSL
   - paramiko
-  - wheel
+  - wheel==0.45.1
   - kubernetes
   - pyasn1
   - wget


### PR DESCRIPTION
 Three issues fixed for Debian/Ubuntu builds:
 
 **1. CloudStack version pinning (Ubuntu)**
 apt install was not version-pinned, so cs4.20.0 builds would install the latest available package (e.g. 4.20.2) instead of the requested version. 

Fix: query the repo with `apt list -a cloudstack-common` to find the exact version string (e.g. 4.20.0.0-shapeblue0), then install with the `=version` constraint.
 
Applies to management server and KVM agent (ubuntu.yml).
 
 **2. CloudStack version pinning (Debian 12)**
 Same fix applied to debian.yml for management server and KVM agent.
 
 **3. wheel package compatibility**
 Pin `wheel` to `0.45.1` in Marvin prereqs to fix a pip compatibility issue with newer wheel versions.

