### PR TITLE
Install packages for Linux network namespace

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/debian.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/debian.yml
@@ -79,9 +79,6 @@
   apt:
     update_cache: yes
 
-- name: Install python3-mysql.connector DEB package for cloudstack-management as the real package name is mysql-connector-python-py3
-  shell: 'wget http://launchpadlibrarian.net/717081070/python3-mysql.connector_8.0.15-4_all.deb -O /tmp/python3-mysql.connector_8.0.15-4_all.deb && DEBIAN_FRONTEND=noninteractive apt install -y /tmp/python3-mysql.connector_8.0.15-4_all.deb'
-
 - name: get CloudStack package version (for example, 4.20.2.0-shapeblue0)
   shell: |
     set -o pipefail

--- a/Ansible/roles/kvm/tasks/centos8.yml
+++ b/Ansible/roles/kvm/tasks/centos8.yml
@@ -86,6 +86,19 @@
   tags:
     - kvm
 
+- name: Install utilities and tools for Linux network namespace
+  dnf: name={{ item }} state=present enablerepo=base
+  with_items:
+    - iproute
+    - iptables
+    - iputils
+    - dnsmasq
+    - haproxy
+    - httpd
+    - util-linux
+  tags:
+    - kvm
+
 - name: install python-argparse
   pip:
     name: argparse

--- a/Ansible/roles/kvm/tasks/centos8.yml
+++ b/Ansible/roles/kvm/tasks/centos8.yml
@@ -96,12 +96,13 @@
     - haproxy
     - httpd
     - util-linux
+    - radvd
   tags:
     - kvm
   ignore_errors: yes
 
-- name: Stop dnsmasq and haproxy and httpd services
-  shell: systemctl stop dnsmasq haproxy httpd && systemctl disable dnsmasq haproxy httpd
+- name: Stop dnsmasq and haproxy and httpd and radvd services
+  shell: systemctl stop dnsmasq haproxy httpd radvd && systemctl disable dnsmasq haproxy httpd radvd
   ignore_errors: yes
 
 - name: install python-argparse

--- a/Ansible/roles/kvm/tasks/centos8.yml
+++ b/Ansible/roles/kvm/tasks/centos8.yml
@@ -98,6 +98,11 @@
     - util-linux
   tags:
     - kvm
+  ignore_errors: yes
+
+- name: Stop dnsmasq and haproxy and httpd services
+  shell: systemctl stop dnsmasq haproxy httpd && systemctl disable dnsmasq haproxy httpd
+  ignore_errors: yes
 
 - name: install python-argparse
   pip:

--- a/Ansible/roles/kvm/tasks/debian.yml
+++ b/Ansible/roles/kvm/tasks/debian.yml
@@ -70,6 +70,20 @@
     - ovmf
     - swtpm
 
+- name: Install utilities and tools for Linux network namespace
+  apt:
+    pkg: "{{ item }}"
+    state: latest
+    update_cache: yes
+  with_items:
+    - iproute2
+    - iptables
+    - arping
+    - dnsmasq
+    - haproxy
+    - apache2
+    - util-linux
+
 - set_fact: java_ver="{{ kvm_java_ver }}"
 - set_fact: java_path="{{ kvm_java_path }}"
 

--- a/Ansible/roles/kvm/tasks/debian.yml
+++ b/Ansible/roles/kvm/tasks/debian.yml
@@ -83,6 +83,11 @@
     - haproxy
     - apache2
     - util-linux
+  ignore_errors: yes
+
+- name: Stop dnsmasq and haproxy and apache2 services
+  shell: systemctl stop dnsmasq haproxy apache2 && systemctl disable dnsmasq haproxy apache2
+  ignore_errors: yes
 
 - set_fact: java_ver="{{ kvm_java_ver }}"
 - set_fact: java_path="{{ kvm_java_path }}"

--- a/Ansible/roles/kvm/tasks/debian.yml
+++ b/Ansible/roles/kvm/tasks/debian.yml
@@ -83,10 +83,11 @@
     - haproxy
     - apache2
     - util-linux
+    - radvd
   ignore_errors: yes
 
-- name: Stop dnsmasq and haproxy and apache2 services
-  shell: systemctl stop dnsmasq haproxy apache2 && systemctl disable dnsmasq haproxy apache2
+- name: Stop dnsmasq and haproxy and apache2 and radvd services
+  shell: systemctl stop dnsmasq haproxy apache2 radvd && systemctl disable dnsmasq haproxy apache2 radvd
   ignore_errors: yes
 
 - set_fact: java_ver="{{ kvm_java_ver }}"

--- a/Ansible/roles/kvm/tasks/el9.yml
+++ b/Ansible/roles/kvm/tasks/el9.yml
@@ -101,6 +101,19 @@
   tags:
     - kvm
 
+- name: Install utilities and tools for Linux network namespace
+  dnf: name={{ item }} state=present enablerepo=base
+  with_items:
+    - iproute
+    - iptables
+    - iputils
+    - dnsmasq
+    - haproxy
+    - httpd
+    - util-linux
+  tags:
+    - kvm
+
 - name: install python-argparse
   pip:
     name: argparse

--- a/Ansible/roles/kvm/tasks/el9.yml
+++ b/Ansible/roles/kvm/tasks/el9.yml
@@ -111,13 +111,14 @@
     - haproxy
     - httpd
     - util-linux
+    - radvd
   tags:
     - kvm
   ignore_errors: yes
 
-- name: Stop dnsmasq and haproxy and httpd services
-  shell: systemctl stop dnsmasq haproxy httpd && systemctl disable dnsmasq haproxy httpd
-  ignore_errors: yes
+- name: Stop dnsmasq and haproxy and httpd and radvd services
+  shell: systemctl stop dnsmasq haproxy httpd radvd && systemctl disable dnsmasq haproxy httpd radvd
+  ignore_errors: yes 
 
 - name: install python-argparse
   pip:

--- a/Ansible/roles/kvm/tasks/el9.yml
+++ b/Ansible/roles/kvm/tasks/el9.yml
@@ -113,6 +113,11 @@
     - util-linux
   tags:
     - kvm
+  ignore_errors: yes
+
+- name: Stop dnsmasq and haproxy and httpd services
+  shell: systemctl stop dnsmasq haproxy httpd && systemctl disable dnsmasq haproxy httpd
+  ignore_errors: yes
 
 - name: install python-argparse
   pip:

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -69,6 +69,20 @@
     - qemu-kvm
     - parted
 
+- name: Install utilities and tools for Linux network namespace
+  apt:
+    pkg: "{{ item }}"
+    state: latest
+    update_cache: yes
+  with_items:
+    - iproute2
+    - iptables
+    - arping
+    - dnsmasq
+    - haproxy
+    - apache2
+    - util-linux
+
 - name: Install packages for UEFI
   apt:
     pkg: "{{ item }}"

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -82,10 +82,11 @@
     - haproxy
     - apache2
     - util-linux
+    - radvd
   ignore_errors: yes
 
-- name: Stop dnsmasq and haproxy and apache2 services
-  shell: systemctl stop dnsmasq haproxy apache2 && systemctl disable dnsmasq haproxy apache2
+- name: Stop dnsmasq and haproxy and apache2 and radvd services
+  shell: systemctl stop dnsmasq haproxy apache2 radvd && systemctl disable dnsmasq haproxy apache2 radvd
   ignore_errors: yes
 
 - name: Install packages for UEFI

--- a/Ansible/roles/kvm/tasks/ubuntu.yml
+++ b/Ansible/roles/kvm/tasks/ubuntu.yml
@@ -82,6 +82,11 @@
     - haproxy
     - apache2
     - util-linux
+  ignore_errors: yes
+
+- name: Stop dnsmasq and haproxy and apache2 services
+  shell: systemctl stop dnsmasq haproxy apache2 && systemctl disable dnsmasq haproxy apache2
+  ignore_errors: yes
 
 - name: Install packages for UEFI
   apt:


### PR DESCRIPTION
install packages
- dnsmasq
- haproxy
- httpd (el8,el9) or apache2 (ubuntu)
- radvd

These services are stopped and disabled on the kvm hosts.