### PR TITLE
Update api key and secret key in the new api_keypair table (for cs version >= 4.23)

### DIFF
--- a/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
@@ -80,7 +80,7 @@
     - "global_settings"
 
 - name: add admin keys for cloudmonkey
-  acs_mysql_update: DBHOST="{{ mysql_master_ip }}" DBUSER="cloud" DBPASS={{ mysql_cloud_password }} MYSQL_STATEMENT="UPDATE `cloud`.`user` SET `api_key`='{{ cm_apikey }}', `secret_key`='{{ cm_secretkey_enc }}' WHERE `id`='2';"
+  acs_mysql_update: DBHOST="{{ mysql_master_ip }}" DBUSER="cloud" DBPASS={{ mysql_cloud_password }} MYSQL_STATEMENT="UPDATE `cloud`.`api_keypair` SET `api_key`='{{ cm_apikey }}', `secret_key`='{{ cm_secretkey_enc }}' WHERE `user_id`='2';"
 
 - name: test for cloud or cloudstack Usage
   stat: path=/etc/init.d/cloudstack-management

--- a/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
+++ b/Ansible/roles/cloudstack-manager/tasks/preconfig_globalsettings.yml
@@ -80,7 +80,12 @@
     - "global_settings"
 
 - name: add admin keys for cloudmonkey
+  acs_mysql_update: DBHOST="{{ mysql_master_ip }}" DBUSER="cloud" DBPASS={{ mysql_cloud_password }} MYSQL_STATEMENT="UPDATE `cloud`.`user` SET `api_key`='{{ cm_apikey }}', `secret_key`='{{ cm_secretkey_enc }}' WHERE `id`='2';"
+  when: env_numversion | version_compare('4.23','<')
+
+- name: add admin keys for cloudmonkey in api_keypair table
   acs_mysql_update: DBHOST="{{ mysql_master_ip }}" DBUSER="cloud" DBPASS={{ mysql_cloud_password }} MYSQL_STATEMENT="UPDATE `cloud`.`api_keypair` SET `api_key`='{{ cm_apikey }}', `secret_key`='{{ cm_secretkey_enc }}' WHERE `user_id`='2';"
+  when: env_numversion | version_compare('4.23','>=')
 
 - name: test for cloud or cloudstack Usage
   stat: path=/etc/init.d/cloudstack-management


### PR DESCRIPTION
Update api key and secret key in the new api_keypair table. This is needed for 4.23.0 onwards, as the API key pair added to new table. 

Ref Upstream PR change here: https://github.com/apache/cloudstack/pull/9504/changes#diff-c2a347e8868908a473213b79695fd81420bee5f97f09c1e1c0d488529e17c80e