### PR TITLE
marvin: install paramiko 4.0.0

### DIFF
--- a/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
+++ b/Ansible/roles/marvin/tasks/install_marvin_prereqs.yml
@@ -92,7 +92,7 @@
   - pip
   - six
   - pyOpenSSL
-  - paramiko
+  - paramiko==4.0.0
   - wheel==0.45.1
   - kubernetes
   - pyasn1


### PR DESCRIPTION
There are several smoke test failures which are caused by SSH connection error to the CentOS 5.5 VMs

Downgrading paramiko from 5.0.0 to 4.0.0 should fix the issues

```
   Test | Result | Time (s) | Test File
   --- | --- | --- | ---
   test_vm_backup_create_vm_from_backup | `Failure` | 608.02 | test_backup_recovery_nas.py
   test_vm_backup_lifecycle | `Error` | 1.12 | test_backup_recovery_nas.py
   test_uservm_host_control_state | `Failure` | 16.98 | test_host_control_state.py
   ContextSuite context=TestSharedFSLifecycle>:setup | `Error` | 0.00 | test_sharedfs_lifecycle.py
   test_10_attachAndDetach_iso | `Failure` | 607.08 | test_vm_life_cycle.py
   test_01_create_vm_snapshots | `Failure` | 606.87 | test_vm_snapshots.py
   test_02_revert_vm_snapshots | `Failure` | 600.67 | test_vm_snapshots.py
   test_03_delete_vm_snapshots | `Failure` | 0.03 | test_vm_snapshots.py
   test_01_create_volume | `Failure` | 610.42 | test_volumes.py
   test_01_root_volume_encryption | `Failure` | 707.39 | test_volumes.py
   test_02_data_volume_encryption | `Failure` | 643.98 | test_volumes.py
   test_03_root_and_data_volume_encryption | `Failure` | 664.23 | test_volumes.py
   test_02_attach_volume | `Failure` | 1270.48 | test_volumes.py
   test_02_attach_volume | `Failure` | 1270.50 | test_volumes.py
   test_03_download_attached_volume | `Failure` | 666.82 | test_volumes.py
   test_04_delete_attached_volume | `Failure` | 663.56 | test_volumes.py
   test_05_detach_volume | `Failure` | 753.78 | test_volumes.py
   test_06_download_detached_volume | `Failure` | 846.01 | test_volumes.py
   test_07_resize_fail | `Failure` | 659.56 | test_volumes.py
   test_08_resize_volume | `Failure` | 673.30 | test_volumes.py
   test_09_delete_detached_volume | `Failure` | 667.03 | test_volumes.py
   test_10_list_volumes | `Failure` | 663.72 | test_volumes.py
   test_11_attach_volume_with_unstarted_vm | `Failure` | 763.48 | test_volumes.py
   test_12_resize_volume_with_only_size_parameter | `Failure` | 666.79 | test_volumes.py
   test_13_migrate_volume_and_change_offering | `Failure` | 806.37 | test_volumes.py
   test_14_delete_volume_delete_protection | `Failure` | 663.90 | test_volumes.py
   test_hostha_enable_ha_when_host_disabled | `Error` | 0.89 | test_hostha_kvm.py
   test_hostha_enable_ha_when_host_in_maintenance | `Error` | 302.13 | test_hostha_kvm.py
```