### PR TITLE
Marvin: Install mysql-connector-python 8.0.30

### DIFF
--- a/Ansible/roles/marvin/tasks/main.yml
+++ b/Ansible/roles/marvin/tasks/main.yml
@@ -79,7 +79,7 @@
 - ```
   pip:
     name: mysql-connector-python==8.0.30
-  when: mgmtsrv_template | lower is search("debian|suse")
+  when: mgmtsrv_template | lower is search("debian|suse|ubuntu")
   tags:
     - marvin
     - marvin_cfg

--- a/Ansible/roles/marvin/tasks/main.yml
+++ b/Ansible/roles/marvin/tasks/main.yml
@@ -75,11 +75,10 @@
     - marvin
     - marvin_cfg
 
-- name: Install mysql-connector-python 8.0.30 for Debian/SUSE/Ubuntu
+- name: Install mysql-connector-python 8.0.30
 - ```
   pip:
     name: mysql-connector-python==8.0.30
-  when: mgmtsrv_template | lower is search("debian|suse|ubuntu")
   tags:
     - marvin
     - marvin_cfg

--- a/Ansible/roles/marvin/tasks/main.yml
+++ b/Ansible/roles/marvin/tasks/main.yml
@@ -75,7 +75,8 @@
     - marvin
     - marvin_cfg
 
-- name: Install mysql-connector-python 8.0.30 for Debian/SUSE
+- name: Install mysql-connector-python 8.0.30 for Debian/SUSE/Ubuntu
+- ```
   pip:
     name: mysql-connector-python==8.0.30
   when: mgmtsrv_template | lower is search("debian|suse")

--- a/Ansible/roles/marvin/tasks/main.yml
+++ b/Ansible/roles/marvin/tasks/main.yml
@@ -75,6 +75,14 @@
     - marvin
     - marvin_cfg
 
+- name: Install mysql-connector-python 8.0.30 for Debian/SUSE
+  pip:
+    name: mysql-connector-python==8.0.30
+  when: mgmtsrv_template | lower is search("debian|suse")
+  tags:
+    - marvin
+    - marvin_cfg
+
 - name: retrieve environment data
   env_db_manage: DBHOST={{ env_db_ip }} DBUSER={{ env_db_user }} DBPASS={{ env_db_password }} DBNAME={{ env_db_name }} ENV_UUID={{ env_uuid }} ENV_NAME={{ env_name_clean }} ENV_ZONETYPE={{ env_zonetype }} ENV_SECGROUPS={{ env_zone_secgroups }} ENV_ACTION=retrieve
   tags:


### PR DESCRIPTION
To fix smoke test failures caused by error

```
import mysql.connector

conn = mysql.connector.connect(
    host="10.0.35.28",
    port=3306,
    user="root",
    password="Pxxxxx",
    database="cloud",
    use_unicode=True,
)

mysql.connector.errors.ProgrammingError: Character set 'utf8' unsupported

```